### PR TITLE
intercept dataset landing pages

### DIFF
--- a/handlers/cmd.go
+++ b/handlers/cmd.go
@@ -2,9 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
-	"math/rand"
 	"net/http"
-	"strconv"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/dp-frontend-models/model"
@@ -66,18 +64,6 @@ func (c *CMD) Landing(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-}
-
-// CreateJobID controls the creating of a job idea when a new user journey is
-// requested
-func (c *CMD) CreateJobID(w http.ResponseWriter, req *http.Request) {
-	// TODO: This is a stubbed job id - replace with real job id from api once
-	// code has been written
-	jobID := rand.Intn(100000000)
-	jid := strconv.Itoa(jobID)
-
-	log.Trace("created job id", log.Data{"job_id": jid})
-	http.Redirect(w, req, "/jobs/"+jid, 301)
 }
 
 // Middle controls the rendering of a "middle" cmd page - this will be replaced

--- a/handlers/cmd_test.go
+++ b/handlers/cmd_test.go
@@ -38,27 +38,6 @@ func TestUnitCMD(t *testing.T) {
 		})
 	})
 
-	Convey("test middle page cmd handler", t, func() {
-		expectedReqBody := `{"type":"","uri":"","taxonomy":null,"breadcrumb":[{"title":"Title of dataset","uri":"/"},{"title":"Filter this dataset","uri":"/"}],"serviceMessage":"","metadata":{"title":"","description":"","keywords":null,"footer":{"enabled":true,"contact":"Matt Rout","release_date":"11 November 2016","next_release":"11 November 2017","dataset_id":"MR"}},"searchDisabled":true,"data":{"job_id":""}}`
-		Convey("test successful request for getting cmd middle page", func() {
-			mr := renderer.NewMockRenderer(mockCtrl)
-			mr.EXPECT().Do("dataset/middlepage", []byte(expectedReqBody)).Return([]byte(`middle-page`), nil)
-
-			c := NewCMD(mr)
-
-			testResponse(200, "middle-page", "/jobs/12345678", c.Middle)
-		})
-
-		Convey("test error thrown when rendering middle page", func() {
-			mr := renderer.NewMockRenderer(mockCtrl)
-			mr.EXPECT().Do("dataset/middlepage", []byte(expectedReqBody)).Return(nil, errors.New("something went wrong with middle page rendering :-("))
-
-			c := NewCMD(mr)
-
-			testResponse(500, "", "/jobs/12345678", c.Middle)
-		})
-	})
-
 	Convey("test landing http finish handler", t, func() {
 		expectedReqBody := `{"type":"","uri":"","taxonomy":null,"breadcrumb":null,"serviceMessage":"","metadata":{"title":"","description":"","keywords":null,"footer":{"enabled":true,"contact":"Matt Rout","release_date":"11 November 2016","next_release":"11 November 2017","dataset_id":"MR"}},"searchDisabled":true}`
 		Convey("test successful request for getting cmd finish page", func() {

--- a/handlers/cmd_test.go
+++ b/handlers/cmd_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
@@ -37,19 +36,6 @@ func TestUnitCMD(t *testing.T) {
 
 			testResponse(500, "", "/datasets/1234/editions/5678/versions/2017", c.Landing)
 		})
-	})
-
-	Convey("test CreateJobID handler, creates a job id and redirects", t, func() {
-		c := NewCMD(nil)
-
-		w := testResponse(301, "", "/datasets/1234/editions/5678/versions/2017/filter", c.CreateJobID)
-
-		location := w.Header().Get("Location")
-		So(location, ShouldNotBeEmpty)
-
-		matched, err := regexp.MatchString(`^\/jobs\/\d{8}$`, location)
-		So(err, ShouldBeNil)
-		So(matched, ShouldBeTrue)
 	})
 
 	Convey("test middle page cmd handler", t, func() {

--- a/main.go
+++ b/main.go
@@ -18,8 +18,6 @@ func main() {
 	rend := renderer.New()
 	cmd := handlers.NewCMD(rend)
 
-	r.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(cmd.Landing)
-	r.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(cmd.CreateJobID)
 	r.Path("/jobs/{jobID}").Methods("GET").HandlerFunc(cmd.Middle)
 
 	r.Path("/jobs/{jobID}/dimensions").Methods("GET").HandlerFunc(cmd.FilterOverview)


### PR DESCRIPTION
### What

- Add the ability to intercept legacy and new (filterable) dataset landing pages

### How to review

- Checkout, build and run all of the following services: dp-frontend-router, dp-frontend-dataset-controller, dp-frontend-filter-dataset-controller, dp-frontent-renderer all on branch feature/intercept-datasets
- Ensure you have sixteens, zebedee and babbage all running
- Ensure you have go-ns checked out on feature/zebedee client
- navigate your browser to http://localhost:20000/economy/economicoutputandproductivity/productivitymeasures/datasets/labourproductivitybyindustrydivision to test the legacy dataset landing page
- navigate your browser to http://localhost:20000/datasets/1234/editions/5678/versions/2017 to test the new dataset landing page (note this is a completely stubbed page with no frontend model as yet)
- Related reviews:

https://github.com/ONSdigital/dp-frontend-renderer/pull/55
https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/6
https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/1
https://github.com/ONSdigital/dp-frontend-router/pull/26
https://github.com/ONSdigital/go-ns/pull/11

### Who can review

Anyone