### PR TITLE
Extend mapper to map api responses to Preview page model

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview"
+	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage"
 )
 
 var dimensionTitleTranslator = map[string]string{
@@ -55,6 +56,49 @@ func CreateFilterOverview(dimensions []data.Dimension, filter data.Filter, datas
 		ReleaseDate: dataset.ReleaseDate,
 		NextRelease: dataset.NextRelease,
 		DatasetID:   dataset.ID,
+	}
+
+	return p
+}
+
+// CreatePreviewPage maps data items from API responses to create a preview page
+func CreatePreviewPage(dimensions []data.Dimension, filter data.Filter, dataset data.Dataset, filterID string) previewPage.Page {
+	var p previewPage.Page
+
+	p.SearchDisabled = true
+
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: dataset.Title,
+		URI:   fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", filter.Dataset, filter.Edition, filter.Version),
+	})
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: "Filter this dataset",
+		URI:   fmt.Sprintf("/filters/%s/dimensions", filterID),
+	})
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: "Preview",
+	})
+
+	p.Data.FilterID = filterID
+
+	p.Metadata.Footer = model.Footer{
+		Enabled:     true,
+		Contact:     dataset.Contact.Name,
+		ReleaseDate: dataset.ReleaseDate,
+		NextRelease: dataset.NextRelease,
+		DatasetID:   dataset.ID,
+	}
+
+	for ext, d := range filter.Downloads {
+		p.Data.Downloads = append(p.Data.Downloads, previewPage.Download{
+			Extension: ext,
+			Size:      d.Size,
+			URI:       d.URL,
+		})
+	}
+
+	for _, dim := range dimensions {
+		p.Data.Dimensions = append(p.Data.Dimensions, previewPage.Dimension(dim))
 	}
 
 	return p

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
+	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -47,6 +48,33 @@ func TestUnitMapper(t *testing.T) {
 		So(fop.Metadata.Footer.ReleaseDate, ShouldEqual, dataset.ReleaseDate)
 		So(fop.Metadata.Footer.DatasetID, ShouldEqual, dataset.ID)
 	})
+
+	Convey("test CreatePreviewPage correctly maps to previewPage frontend model", t, func() {
+		dimensions := getTestDimensions()
+		filter := getTestFilter()
+		dataset := getTestDataset()
+
+		pp := CreatePreviewPage(dimensions, filter, dataset, filter.FilterID)
+		So(pp.SearchDisabled, ShouldBeTrue)
+		So(pp.Breadcrumb, ShouldHaveLength, 3)
+		So(pp.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
+		So(pp.Breadcrumb[0].URI, ShouldEqual, "/datasets/"+filter.Dataset+"/editions/"+filter.Edition+"/versions/"+filter.Version)
+		So(pp.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
+		So(pp.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(pp.Breadcrumb[2].Title, ShouldEqual, "Preview")
+		So(pp.Data.FilterID, ShouldEqual, filter.FilterID)
+		So(pp.Metadata.Footer.Enabled, ShouldBeTrue)
+		So(pp.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(pp.Metadata.Footer.ReleaseDate, ShouldEqual, dataset.ReleaseDate)
+		So(pp.Metadata.Footer.DatasetID, ShouldEqual, dataset.ID)
+		So(pp.Data.Downloads[0].Extension, ShouldEqual, "csv")
+		So(pp.Data.Downloads[0].Size, ShouldEqual, "362783")
+		So(pp.Data.Downloads[0].URI, ShouldEqual, "/")
+
+		for i, dim := range pp.Data.Dimensions {
+			So(dim, ShouldResemble, previewPage.Dimension(dimensions[i]))
+		}
+	})
 }
 
 func getTestDimensions() []data.Dimension {
@@ -76,6 +104,16 @@ func getTestFilter() data.Filter {
 		Edition:  "12345",
 		Dataset:  "849209",
 		Version:  "2017",
+		Downloads: map[string]data.Download{
+			"csv": {
+				Size: "362783",
+				URL:  "/",
+			},
+			"xls": {
+				Size: "373929",
+				URL:  "/",
+			},
+		},
 	}
 }
 

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
@@ -10,5 +10,20 @@ type Page struct {
 
 // PreviewPage ...
 type PreviewPage struct {
-	FilterID string `json:"filter_id"`
+	FilterID   string      `json:"filter_id"`
+	Downloads  []Download  `json:"downloads"`
+	Dimensions []Dimension `json:"dimensions"`
+}
+
+// Download has the details for an individual downloadable files
+type Download struct {
+	Extension string `json:"extension"`
+	Size      string `json:"size"`
+	URI       string `json:"uri"`
+}
+
+// Dimension ...
+type Dimension struct {
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-07-18T12:33:43Z"
 		},
 		{
-			"checksumSHA1": "4uRiiVK0fCA9oQdzI7yi6a3LdJM=",
+			"checksumSHA1": "XiB1eoyvRBkRzkGyrjjJwsXA+Go=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
-			"revision": "fd87760f288b942010fdb9db9ae9ffe91212ad36",
-			"revisionTime": "2017-07-18T12:33:43Z"
+			"revision": "87180bd5ba6e86bf6e1d756daaedd77ef3acd72d",
+			"revisionTime": "2017-07-24T10:41:27Z"
 		},
 		{
 			"checksumSHA1": "fAyPS71FyNTWhcs+JmSkZupUaeE=",


### PR DESCRIPTION
### What

Extend mapper to map api response data to frontend model for preview and download page

### How to review

- Start the service on this branch and the renderer on feature/datsetlandingpage-filterable and all the other usual f/end services on cmd-develop
- Verify that when you visit a preview and download page that the page renders correctly (using stubbed api response data)

### Who can review

Anyone
