### PR TITLE
Add ability to select time dimension and values within it

### DIFF
--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -1,0 +1,66 @@
+package codelist
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
+)
+
+// ErrInvalidCodelistAPIResponse is returned when the codelist api does not respond
+// with a valid status
+type ErrInvalidCodelistAPIResponse struct {
+	expectedCode int
+	actualCode   int
+	uri          string
+}
+
+func (e ErrInvalidCodelistAPIResponse) Error() string {
+	return fmt.Sprintf("invalid response from codelist api - should be: %d, got: %d, path: %s",
+		e.expectedCode,
+		e.actualCode,
+		e.uri,
+	)
+}
+
+var _ error = ErrInvalidCodelistAPIResponse{}
+
+// Client is a codelist api client which can be used to make requests to the server
+type Client struct {
+	cli *http.Client
+	url string
+}
+
+// New creates a new instance of Client with a given filter api url
+func New(codelistAPIURL string) *Client {
+	return &Client{
+		cli: &http.Client{Timeout: 5 * time.Second},
+		url: codelistAPIURL,
+	}
+}
+
+// GetValues ...
+func (c *Client) GetValues(id string) (vals data.DimensionValues, err error) {
+	uri := fmt.Sprintf("%s/code-lists/%s/codes", c.url, id)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidCodelistAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &vals)
+	return
+}

--- a/config/config.go
+++ b/config/config.go
@@ -4,18 +4,22 @@ import "os"
 
 // Config represents service configuration for dp-frontend-filter-dataset-controller
 type Config struct {
-	BindAddr     string
-	RendererURL  string
-	FilterAPIURL string
+	BindAddr       string
+	RendererURL    string
+	FilterAPIURL   string
+	DatasetAPIURL  string
+	CodeListAPIURL string
 }
 
 // Get returns the default config with any modifications through environment
 // variables
 func Get() *Config {
 	cfg := &Config{
-		BindAddr:     ":20001",
-		RendererURL:  "http://localhost:20010",
-		FilterAPIURL: "",
+		BindAddr:       ":20001",
+		RendererURL:    "http://localhost:20010",
+		CodeListAPIURL: "http://localhost:22400",
+		FilterAPIURL:   "http://localhost:20011",
+		DatasetAPIURL:  "http://localhost:20012",
 	}
 
 	if v := os.Getenv("BIND_ADDR"); len(v) > 0 {
@@ -26,6 +30,9 @@ func Get() *Config {
 	}
 	if v := os.Getenv("FILTER_API_URL"); len(v) > 0 {
 		cfg.FilterAPIURL = v
+	}
+	if v := os.Getenv("CODELIST_API_URL"); len(v) > 0 {
+		cfg.CodeListAPIURL = v
 	}
 
 	return cfg

--- a/data/data.go
+++ b/data/data.go
@@ -6,12 +6,31 @@ type Dimension struct {
 	Values []string `json:"values"`
 }
 
+// FilterDimension represents a dimension response from the filter api
+type FilterDimension struct {
+	Name string `json:"name"`
+	URI  string `json:"dimension_url"`
+}
+
+// FilterDimensionValues ...
+type FilterDimensionValues struct {
+	Items           []FilterDimensionValueItem `json:"items"`
+	NumberOfResults int                        `json:"number_of_results"`
+}
+
+// FilterDimensionValueItem ...
+type FilterDimensionValueItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 // Filter represents a response model from the filter api
 type Filter struct {
 	FilterID   string              `json:"filter_id"`
 	Dataset    string              `json:"dataset"`
 	Edition    string              `json:"edition"`
-	Version    string              `json:"state"`
+	Version    string              `json:"version"`
+	State      string              `json:"state"`
 	Dimensions []Dimension         `json:"dimensions"`
 	Downloads  map[string]Download `json:"downloads"`
 	Events     map[string][]Event  `json:"events"`

--- a/data/data.go
+++ b/data/data.go
@@ -12,16 +12,17 @@ type FilterDimension struct {
 	URI  string `json:"dimension_url"`
 }
 
-// FilterDimensionValues ...
-type FilterDimensionValues struct {
-	Items           []FilterDimensionValueItem `json:"items"`
-	NumberOfResults int                        `json:"number_of_results"`
+// DimensionValues ...
+type DimensionValues struct {
+	Items           []DimensionValueItem `json:"items"`
+	NumberOfResults int                  `json:"number_of_results"`
 }
 
-// FilterDimensionValueItem ...
-type FilterDimensionValueItem struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+// DimensionValueItem ...
+type DimensionValueItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Name  string `json:"name"`
 }
 
 // Filter represents a response model from the filter api

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -1,0 +1,66 @@
+package dataset
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
+)
+
+// ErrInvalidDatasetAPIResponse is returned when the dataset api does not respond
+// with a valid status
+type ErrInvalidDatasetAPIResponse struct {
+	expectedCode int
+	actualCode   int
+	uri          string
+}
+
+func (e ErrInvalidDatasetAPIResponse) Error() string {
+	return fmt.Sprintf("invalid response from dataset api - should be: %d, got: %d, path: %s",
+		e.expectedCode,
+		e.actualCode,
+		e.uri,
+	)
+}
+
+var _ error = ErrInvalidDatasetAPIResponse{}
+
+// Client is a dataset api client which can be used to make requests to the server
+type Client struct {
+	cli *http.Client
+	url string
+}
+
+// New creates a new instance of Client with a given filter api url
+func New(datasetAPIURL string) *Client {
+	return &Client{
+		cli: &http.Client{Timeout: 5 * time.Second},
+		url: datasetAPIURL,
+	}
+}
+
+// GetDataset ...
+func (c *Client) GetDataset(id, edition, version string) (d data.Dataset, err error) {
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s", c.url, id, edition, version)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidDatasetAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &d)
+	return
+}

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -41,6 +41,11 @@ func ConvertToReadable(dates []string) ([]time.Time, error) {
 	return readableDates, nil
 }
 
+// ConvertToMonthYear takes a time.Time object and converts to MM yyyy
+func ConvertToMonthYear(d time.Time) string {
+	return fmt.Sprintf("%s %d", d.Month().String(), d.Year())
+}
+
 // Sort orders a list of times
 func Sort(dates []time.Time) TimeSlice {
 	d := TimeSlice(dates)

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -1,0 +1,1 @@
+func dates

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -1,1 +1,61 @@
-func dates
+package dates
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"time"
+)
+
+// TimeSlice allows sorting of a list of time.Time
+type TimeSlice []time.Time
+
+func (p TimeSlice) Len() int {
+	return len(p)
+}
+
+func (p TimeSlice) Less(i, j int) bool {
+	return p[i].Before(p[j])
+}
+
+func (p TimeSlice) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+// ConvertToReadable takes a list of dates in the format yyyy.mm and converts to
+// a list of time.Time
+func ConvertToReadable(dates []string) ([]time.Time, error) {
+	var readableDates []time.Time
+	for _, val := range dates {
+		myrReg := regexp.MustCompile(`^(\d{4})\.(\d{1}|\d{2})$`)
+		myrSubs := myrReg.FindStringSubmatch(val)
+		if len(myrSubs) == 3 {
+			date, err := time.Parse("01-02-2006", fmt.Sprintf("%02s-01-%s", myrSubs[2], myrSubs[1]))
+			if err != nil {
+				return readableDates, err
+			}
+			readableDates = append(readableDates, date)
+		}
+	}
+
+	return readableDates, nil
+}
+
+// Sort orders a list of times
+func Sort(dates []time.Time) TimeSlice {
+	d := TimeSlice(dates)
+	sort.Sort(d)
+
+	return d
+}
+
+// ConvertToCoded takes a list of time.Time and converts to a list of strings in
+// the format yyyy.mm
+func ConvertToCoded(dates []time.Time) []string {
+	var codedDates []string
+	for _, date := range dates {
+		codedDates = append(codedDates, fmt.Sprintf("%d.%02d", date.Year(), date.Month()))
+	}
+
+	return codedDates
+}

--- a/dates/dates_test.go
+++ b/dates/dates_test.go
@@ -1,0 +1,54 @@
+package dates
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitDates(t *testing.T) {
+	Convey("test ConvertToReadable", t, func() {
+		Convey("converts a string slice with values in the format `yyyy.mm` to time.Time slice", func() {
+			times, err := ConvertToReadable([]string{"2006.05"})
+			So(err, ShouldBeNil)
+			So(times, ShouldHaveLength, 1)
+			So(times[0].Month().String(), ShouldEqual, "May")
+			So(times[0].Year(), ShouldEqual, 2006)
+		})
+
+		Convey("test error thrown if unable to parse date", func() {
+			times, err := ConvertToReadable([]string{"2010.13"})
+			So(err, ShouldNotBeNil)
+			So(times, ShouldBeEmpty)
+		})
+	})
+
+	Convey("test ConvertToMonthYear", t, func() {
+		time, err := time.Parse("01-02-2006", "05-01-2006")
+		So(err, ShouldBeNil)
+		formattedData := ConvertToMonthYear(time)
+		So(formattedData, ShouldEqual, "May 2006")
+	})
+
+	Convey("test Sort sorts a list of times", t, func() {
+		time1, _ := time.Parse("01-02-2006", "07-01-2006")
+		time2, _ := time.Parse("01-02-2006", "02-01-2006")
+		time3, _ := time.Parse("01-02-2006", "10-01-2006")
+		times := Sort([]time.Time{time1, time2, time3})
+		So(times[0].Equal(time2), ShouldBeTrue)
+		So(times[1].Equal(time1), ShouldBeTrue)
+		So(times[2].Equal(time3), ShouldBeTrue)
+	})
+
+	Convey("test ConvertToCoded converts a time list to a coded string list", t, func() {
+		time1, _ := time.Parse("01-02-2006", "07-01-2006")
+		time2, _ := time.Parse("01-02-2006", "02-01-2006")
+		time3, _ := time.Parse("01-02-2006", "10-01-2006")
+
+		codedDates := ConvertToCoded([]time.Time{time1, time2, time3})
+		So(codedDates[0], ShouldEqual, "2006.07")
+		So(codedDates[1], ShouldEqual, "2006.02")
+		So(codedDates[2], ShouldEqual, "2006.10")
+	})
+}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -142,6 +142,26 @@ func (c *Client) AddDimensionValue(filterID, name, value string) error {
 	return nil
 }
 
+// RemoveDimensionValue removes a particular value to a filter job for a given filterID
+// and name
+func (c *Client) RemoveDimensionValue(filterID, name, value string) error {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options/%s", c.url, filterID, name, value)
+	req, err := http.NewRequest("DELETE", uri, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+	}
+	return nil
+}
+
 // GetJobState ...
 func (c *Client) GetJobState(filterID string) (f data.Filter, err error) {
 	uri := fmt.Sprintf("%s/filters/%s", c.url, filterID)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -122,6 +122,26 @@ func (c *Client) GetDimensionOptions(filterID, name string) (fdv data.DimensionV
 	return
 }
 
+// AddDimensionValue adds a particular value to a filter job for a given filterID
+// and name
+func (c *Client) AddDimensionValue(filterID, name, value string) error {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options/%s", c.url, filterID, name, value)
+	req, err := http.NewRequest("POST", uri, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return &ErrInvalidFilterAPIResponse{http.StatusCreated, resp.StatusCode, uri}
+	}
+	return nil
+}
+
 // GetJobState ...
 func (c *Client) GetJobState(filterID string) (f data.Filter, err error) {
 	uri := fmt.Sprintf("%s/filters/%s", c.url, filterID)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,0 +1,120 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
+)
+
+// ErrInvalidFilterAPIResponse is returned when the filter api does not respond
+// with a valid status
+type ErrInvalidFilterAPIResponse struct {
+	expectedCode int
+	actualCode   int
+	uri          string
+}
+
+func (e ErrInvalidFilterAPIResponse) Error() string {
+	return fmt.Sprintf("invalid response from filter api - should be: %d, got: %d, path: %s",
+		e.expectedCode,
+		e.actualCode,
+		e.uri,
+	)
+}
+
+var _ error = ErrInvalidFilterAPIResponse{}
+
+// Client is a filter api client which can be used to make requests to the server
+type Client struct {
+	cli *http.Client
+	url string
+}
+
+// New creates a new instance of Client with a given filter api url
+func New(filterAPIURL string) *Client {
+	return &Client{
+		cli: &http.Client{Timeout: 5 * time.Second},
+		url: filterAPIURL,
+	}
+}
+
+// GetDimensions will return the dimensions associated with the provided filter id
+func (c *Client) GetDimensions(filterID string) (dims []data.FilterDimension, err error) {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions", c.url, filterID)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	dimensions := struct {
+		Dims []data.FilterDimension `json:"dimensions"`
+	}{}
+
+	if err = json.Unmarshal(b, &dimensions); err != nil {
+		return
+	}
+
+	dims = dimensions.Dims
+	return
+}
+
+// GetDimensionOptions ...
+func (c *Client) GetDimensionOptions(filterID, name string) (fdv data.FilterDimensionValues, err error) {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options", c.url, filterID, name)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &fdv)
+	return
+}
+
+// GetJobState ...
+func (c *Client) GetJobState(filterID string) (f data.Filter, err error) {
+	uri := fmt.Sprintf("%s/filters/%s", c.url, filterID)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &f)
+	return
+}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -42,6 +42,32 @@ func New(filterAPIURL string) *Client {
 	}
 }
 
+// GetDimension returns information on a requested dimension name for a given filterID
+func (c *Client) GetDimension(filterID, name string) (dim data.FilterDimension, err error) {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s", c.url, filterID, name)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if err = json.Unmarshal(b, &dim); err != nil {
+		return
+	}
+
+	return
+}
+
 // GetDimensions will return the dimensions associated with the provided filter id
 func (c *Client) GetDimensions(filterID string) (dims []data.FilterDimension, err error) {
 	uri := fmt.Sprintf("%s/filters/%s/dimensions", c.url, filterID)
@@ -74,7 +100,7 @@ func (c *Client) GetDimensions(filterID string) (dims []data.FilterDimension, er
 }
 
 // GetDimensionOptions ...
-func (c *Client) GetDimensionOptions(filterID, name string) (fdv data.FilterDimensionValues, err error) {
+func (c *Client) GetDimensionOptions(filterID, name string) (fdv data.DimensionValues, err error) {
 	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options", c.url, filterID, name)
 	resp, err := c.cli.Get(uri)
 	if err != nil {

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -1,0 +1,15 @@
+package handlers
+
+import "github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
+
+// FilterClient contains the methods expected for a filter client
+type FilterClient interface {
+	GetDimensions(filterID string) (dims []data.FilterDimension, err error)
+	GetDimensionOptions(filterID, name string) (fdv data.FilterDimensionValues, err error)
+	GetJobState(filterID string) (f data.Filter, err error)
+}
+
+// DatasetClient ...
+type DatasetClient interface {
+	GetDataset(id, edition, version string) (d data.Dataset, err error)
+}

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -8,6 +8,7 @@ type FilterClient interface {
 	GetDimensionOptions(filterID, name string) (fdv data.DimensionValues, err error)
 	GetJobState(filterID string) (f data.Filter, err error)
 	GetDimension(filterID, name string) (dim data.FilterDimension, err error)
+	AddDimensionValue(filterID, name, value string) error
 }
 
 // DatasetClient ...

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -5,11 +5,17 @@ import "github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
 // FilterClient contains the methods expected for a filter client
 type FilterClient interface {
 	GetDimensions(filterID string) (dims []data.FilterDimension, err error)
-	GetDimensionOptions(filterID, name string) (fdv data.FilterDimensionValues, err error)
+	GetDimensionOptions(filterID, name string) (fdv data.DimensionValues, err error)
 	GetJobState(filterID string) (f data.Filter, err error)
+	GetDimension(filterID, name string) (dim data.FilterDimension, err error)
 }
 
 // DatasetClient ...
 type DatasetClient interface {
 	GetDataset(id, edition, version string) (d data.Dataset, err error)
+}
+
+// CodelistClient ...
+type CodelistClient interface {
+	GetValues(id string) (vals data.DimensionValues, err error)
 }

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -9,6 +9,7 @@ type FilterClient interface {
 	GetJobState(filterID string) (f data.Filter, err error)
 	GetDimension(filterID, name string) (dim data.FilterDimension, err error)
 	AddDimensionValue(filterID, name, value string) error
+	RemoveDimensionValue(filterID, name, value string) error
 }
 
 // DatasetClient ...

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/ageSelectorList"
-	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/ageSelectorRange"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/geography"
+	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/mux"
 )
@@ -263,35 +263,39 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 	w.Write(templateBytes)
 }
 
-// AgeSelectorRange controls the render of the age selector template
+// RangeSelector controls the render of the range selector template
 // Contains stubbed data for now - page to be populated by the API
-func (f *Filter) AgeSelectorRange(w http.ResponseWriter, req *http.Request) {
-	p := ageSelectorRange.Page{
+func (f *Filter) RangeSelector(w http.ResponseWriter, req *http.Request) {
+	p := rangeSelector.Page{
 		FilterID: "12345",
-		Data: ageSelectorRange.AgeSelectorRange{
-			AddFromList: ageSelectorRange.Link{
-				URL: "/filters/12345/dimensions/age-list",
+		Data: rangeSelector.RangeSelector{
+			AddFromList: rangeSelector.Link{
+				Label: "Add age range",
+				URL:   "/filters/12345/dimensions/age-list",
 			},
 			NumberOfSelectors: 1,
-			AddAges: ageSelectorRange.Link{
+			AddRange: rangeSelector.Link{
 				Label: "Add ages",
 				URL:   "/add-to-basket/",
 			},
-			AddNewRange: ageSelectorRange.Link{
+			AddAllInRange: rangeSelector.Link{
+				Label: "All ages",
+			},
+			AddNewRange: rangeSelector.Link{
 				URL: "/add-another-range",
 			},
-			RemoveRange: ageSelectorRange.Link{
+			RemoveRange: rangeSelector.Link{
 				URL:   "/remove-range",
 				Label: "Remove",
 			},
-			SaveAndReturn: ageSelectorRange.Link{
+			SaveAndReturn: rangeSelector.Link{
 				URL: "/filters/12345/dimensions",
 			},
-			Cancel: ageSelectorRange.Link{
+			Cancel: rangeSelector.Link{
 				URL: "/filters/12345/dimensions",
 			},
 			FiltersAmount: 2,
-			FiltersAdded: []ageSelectorRange.Filter{
+			FiltersAdded: []rangeSelector.Filter{
 				{
 					RemoveURL: "/remove-this/",
 					Label:     "All ages",
@@ -305,12 +309,15 @@ func (f *Filter) AgeSelectorRange(w http.ResponseWriter, req *http.Request) {
 					Label:     "18",
 				},
 			},
-			RemoveAll: ageSelectorRange.Link{
+			RemoveAll: rangeSelector.Link{
 				URL: "/remove-all/",
 			},
-			AgeRange: ageSelectorRange.Range{
-				StartNum: 30,
-				EndNum:   90,
+			RangeData: rangeSelector.Range{
+				StartNum:     30,
+				EndNum:       90,
+				StartLabel:   "Youngest",
+				EndLabel:     "Oldest",
+				AppendString: "and over",
 			},
 		},
 	}
@@ -337,7 +344,7 @@ func (f *Filter) AgeSelectorRange(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	templateBytes, err := f.r.Do("dataset-filter/age-selector-range", b)
+	templateBytes, err := f.r.Do("dataset-filter/range-selector", b)
 	if err != nil {
 		log.Error(err, nil)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/mapper"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/dp-frontend-models/model"
-	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/ageSelectorList"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/geography"
+	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/mux"
@@ -354,22 +354,26 @@ func (f *Filter) RangeSelector(w http.ResponseWriter, req *http.Request) {
 	w.Write(templateBytes)
 }
 
-// AgeSelectorList controls the render of the age selector list template
+// ListSelector controls the render of the age selector list template
 // Contains stubbed data for now - page to be populated by the API
-func (f *Filter) AgeSelectorList(w http.ResponseWriter, req *http.Request) {
-	p := ageSelectorList.Page{
+func (f *Filter) ListSelector(w http.ResponseWriter, req *http.Request) {
+	p := listSelector.Page{
 		FilterID: "12345",
-		Data: ageSelectorList.AgeSelectorList{
-			AddFromRange: ageSelectorList.Link{
-				URL: "/filters/12345/dimensions/age-range",
+		Data: listSelector.ListSelector{
+			AddFromRange: listSelector.Link{
+				Label: "add age range",
+				URL:   "/filters/12345/dimensions/age-range",
 			},
-			SaveAndReturn: ageSelectorList.Link{
+			SaveAndReturn: listSelector.Link{
 				URL: "/filters/12345/dimensions",
 			},
-			Cancel: ageSelectorList.Link{
+			AddAllInRange: listSelector.Link{
+				Label: "All ages",
+			},
+			Cancel: listSelector.Link{
 				URL: "/filters/12345/dimensions",
 			},
-			FiltersAdded: []ageSelectorList.Filter{
+			FiltersAdded: []listSelector.Filter{
 				{
 					RemoveURL: "/remove-this/",
 					Label:     "All ages",
@@ -383,13 +387,16 @@ func (f *Filter) AgeSelectorList(w http.ResponseWriter, req *http.Request) {
 					Label:     "18",
 				},
 			},
-			RemoveAll: ageSelectorList.Link{
+			RemoveAll: listSelector.Link{
 				URL: "/remove-all/",
 			},
 			FiltersAmount: 2,
-			AgeRange: ageSelectorList.Range{
-				StartNum: 30,
-				EndNum:   90,
+			RangeData: listSelector.Range{
+				StartNum:     30,
+				EndNum:       90,
+				StartLabel:   "Youngest",
+				EndLabel:     "Oldest",
+				AppendString: "and over",
 			},
 		},
 	}
@@ -416,7 +423,7 @@ func (f *Filter) AgeSelectorList(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	templateBytes, err := f.r.Do("dataset-filter/age-selector-list", b)
+	templateBytes, err := f.r.Do("dataset-filter/list-selector", b)
 	if err != nil {
 		log.Error(err, nil)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -327,20 +327,8 @@ func (f *Filter) DimensionSelector(w http.ResponseWriter, req *http.Request) {
 }
 
 func (f *Filter) rangeSelector(w http.ResponseWriter, req *http.Request, name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset) {
-	ns := req.URL.Query().Get("nSelectors")
 
-	var nSelectors int
-	var err error
-	if ns == "" {
-		nSelectors = 1
-	} else {
-		nSelectors, err = strconv.Atoi(ns)
-		if err != nil {
-			nSelectors = 1
-		}
-	}
-
-	p := mapper.CreateRangeSelectorPage(name, selectedValues, allValues, filter, dataset, nSelectors)
+	p := mapper.CreateRangeSelectorPage(name, selectedValues, allValues, filter, dataset)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/geography"
-	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/mux"
 )
@@ -321,7 +320,7 @@ func (f *Filter) DimensionSelector(w http.ResponseWriter, req *http.Request) {
 
 	selectorType := req.URL.Query().Get("selectorType")
 	if selectorType == "list" {
-		f.listSelector(w, req)
+		f.listSelector(w, req, name, selectedValues, allValues, filter, dataset)
 	} else {
 		f.rangeSelector(w, req, name, selectedValues, allValues, filter, dataset)
 	}
@@ -362,65 +361,8 @@ func (f *Filter) rangeSelector(w http.ResponseWriter, req *http.Request, name st
 
 // ListSelector controls the render of the age selector list template
 // Contains stubbed data for now - page to be populated by the API
-func (f *Filter) listSelector(w http.ResponseWriter, req *http.Request) {
-	p := listSelector.Page{
-		FilterID: "12345",
-		Data: listSelector.ListSelector{
-			AddFromRange: listSelector.Link{
-				Label: "add age range",
-				URL:   "/filters/12345/dimensions/age-range",
-			},
-			SaveAndReturn: listSelector.Link{
-				URL: "/filters/12345/dimensions",
-			},
-			AddAllInRange: listSelector.Link{
-				Label: "All ages",
-			},
-			Cancel: listSelector.Link{
-				URL: "/filters/12345/dimensions",
-			},
-			FiltersAdded: []listSelector.Filter{
-				{
-					RemoveURL: "/remove-this/",
-					Label:     "All ages",
-				},
-				{
-					RemoveURL: "/remove-this-2/",
-					Label:     "43",
-				},
-				{
-					RemoveURL: "/remove-this-3/",
-					Label:     "18",
-				},
-			},
-			RemoveAll: listSelector.Link{
-				URL: "/remove-all/",
-			},
-			FiltersAmount: 2,
-			RangeData: listSelector.Range{
-				StartNum:     30,
-				EndNum:       90,
-				StartLabel:   "Youngest",
-				EndLabel:     "Oldest",
-				AppendString: "and over",
-			},
-		},
-	}
-
-	p.Breadcrumb = []model.TaxonomyNode{
-		{
-			Title: "Title of dataset",
-			URI:   "/",
-		},
-		{
-			Title: "Filter this dataset",
-			URI:   "/",
-		},
-	}
-
-	p.SearchDisabled = true
-
-	p.Metadata.Footer = getStubbedMetadataFooter()
+func (f *Filter) listSelector(w http.ResponseWriter, req *http.Request, name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset) {
+	p := mapper.CreateListSelectorPage(name, selectedValues, allValues, filter, dataset)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1,0 +1,8 @@
+package handlers
+
+import "net/http"
+
+// Validator provides methods a to validate a request
+type Validator interface {
+	Validate(*http.Request, interface{}) error
+}

--- a/main.go
+++ b/main.go
@@ -45,8 +45,10 @@ func main() {
 	r.Path("/filters/{filterID}/dimensions/geography").Methods("GET").HandlerFunc(filter.Geography)
 
 	r.Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(filter.DimensionSelector)
-	r.Path("/filters/{filterID}/dimensions/{name}/range-add").Methods("POST").HandlerFunc(filter.AddRange)
-	r.Path("/filters/{filterID}/dimensions/{name}/range-delete").Methods("POST").HandlerFunc(filter.RemoveRange)
+	r.Path("/filters/{filterID}/dimensions/{name}/remove-all").HandlerFunc(filter.DimensionRemoveAll)
+	r.Path("/filters/{filterID}/dimensions/{name}/remove/{option}").HandlerFunc(filter.DimensionRemoveOne)
+	r.Path("/filters/{filterID}/dimensions/{name}/range").Methods("POST").HandlerFunc(filter.AddRange)
+	r.Path("/filters/{filterID}/dimensions/{name}/list").Methods("POST").HandlerFunc(filter.AddList)
 
 	s := server.New(cfg.BindAddr, r)
 

--- a/main.go
+++ b/main.go
@@ -40,11 +40,11 @@ func main() {
 
 	r.Path("/filters/{filterID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 	r.Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(filter.FilterOverview)
-	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.RangeSelector)
-	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.ListSelector)
+	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.DimensionSelector)
+	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.DimensionSelector)
 	r.Path("/filters/{filterID}/dimensions/geography").Methods("GET").HandlerFunc(filter.Geography)
 
-	r.Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(filter.RangeSelector)
+	r.Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(filter.DimensionSelector)
 	r.Path("/filters/{filterID}/dimensions/{name}/range-add").Methods("POST").HandlerFunc(filter.AddRange)
 	r.Path("/filters/{filterID}/dimensions/{name}/range-delete").Methods("POST").HandlerFunc(filter.RemoveRange)
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/codelist"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dataset"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/filter"
@@ -8,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/server"
+	"github.com/ONSdigital/go-ns/validator"
 	"github.com/gorilla/mux"
 )
 
@@ -17,16 +21,32 @@ func main() {
 
 	r := mux.NewRouter()
 
+	fi, err := os.Open("rules.json")
+	if err != nil {
+		log.ErrorC("could not open rules for validation", err, nil)
+	}
+	defer fi.Close()
+
+	v, err := validator.New(fi)
+	if err != nil {
+		log.ErrorC("failed to crare form validator", err, nil)
+	}
+
 	rend := renderer.New()
 	fc := filter.New(cfg.FilterAPIURL)
 	dc := dataset.New(cfg.DatasetAPIURL)
-	filter := handlers.NewFilter(rend, fc, dc)
+	clc := codelist.New(cfg.CodeListAPIURL)
+	filter := handlers.NewFilter(rend, fc, dc, clc, v)
 
 	r.Path("/filters/{filterID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 	r.Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(filter.FilterOverview)
 	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.RangeSelector)
 	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.ListSelector)
 	r.Path("/filters/{filterID}/dimensions/geography").Methods("GET").HandlerFunc(filter.Geography)
+
+	r.Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(filter.RangeSelector)
+	r.Path("/filters/{filterID}/dimensions/{name}/range-add").Methods("POST").HandlerFunc(filter.AddRange)
+	r.Path("/filters/{filterID}/dimensions/{name}/range-delete").Methods("POST").HandlerFunc(filter.RemoveRange)
 
 	s := server.New(cfg.BindAddr, r)
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dataset"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/filter"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/renderer"
 	"github.com/ONSdigital/go-ns/log"
@@ -16,7 +18,9 @@ func main() {
 	r := mux.NewRouter()
 
 	rend := renderer.New()
-	filter := handlers.NewFilter(rend)
+	fc := filter.New(cfg.FilterAPIURL)
+	dc := dataset.New(cfg.DatasetAPIURL)
+	filter := handlers.NewFilter(rend, fc, dc)
 
 	r.Path("/filters/{filterID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 	r.Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(filter.FilterOverview)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	r.Path("/filters/{filterID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 	r.Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(filter.FilterOverview)
 	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.RangeSelector)
-	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.AgeSelectorList)
+	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.ListSelector)
 	r.Path("/filters/{filterID}/dimensions/geography").Methods("GET").HandlerFunc(filter.Geography)
 
 	s := server.New(cfg.BindAddr, r)

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	r.Path("/filters/{filterID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 	r.Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(filter.FilterOverview)
-	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.AgeSelectorRange)
+	r.Path("/filters/{filterID}/dimensions/age-range").Methods("GET").HandlerFunc(filter.RangeSelector)
 	r.Path("/filters/{filterID}/dimensions/age-list").Methods("GET").HandlerFunc(filter.AgeSelectorList)
 	r.Path("/filters/{filterID}/dimensions/geography").Methods("GET").HandlerFunc(filter.Geography)
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -2,12 +2,14 @@ package mapper
 
 import (
 	"fmt"
+	"math/rand"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/data"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector"
+	"github.com/ONSdigital/go-ns/log"
 )
 
 var dimensionTitleTranslator = map[string]string{
@@ -136,6 +138,14 @@ func CreateRangeSelectorPage(name string, selectedValues, allValues data.Dimensi
 	}
 
 	return p
+
+}
+
+// Random boolean generator
+func randBool() bool {
+	b := rand.Float32() < 0.5
+	log.Debug("random bool", log.Data{"bool": b})
+	return b
 }
 
 // CreatePreviewPage maps data items from API responses to create a preview page
@@ -177,6 +187,8 @@ func CreatePreviewPage(dimensions []data.Dimension, filter data.Filter, dataset 
 	for _, dim := range dimensions {
 		p.Data.Dimensions = append(p.Data.Dimensions, previewPage.Dimension(dim))
 	}
+
+	p.IsContentLoaded = randBool()
 
 	return p
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -10,10 +10,12 @@ import (
 )
 
 var dimensionTitleTranslator = map[string]string{
-	"geography": "Geographic Areas",
-	"year":      "Year",
-	"age-range": "Age",
-	"sex":       "Sex",
+	"geography":          "Geographic Areas",
+	"year":               "Year",
+	"age-range":          "Age",
+	"sex":                "Sex",
+	"month":              "Month",
+	"goods-and-services": "Goods and Services",
 }
 
 // CreateFilterOverview maps data items from API responses to form a filter overview

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage"
+	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector"
 )
 
 var dimensionTitleTranslator = map[string]string{
@@ -51,6 +52,80 @@ func CreateFilterOverview(dimensions []data.Dimension, filter data.Filter, datas
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter this dataset",
 	})
+
+	p.Metadata.Footer = model.Footer{
+		Enabled:     true,
+		Contact:     dataset.Contact.Name,
+		ReleaseDate: dataset.ReleaseDate,
+		NextRelease: dataset.NextRelease,
+		DatasetID:   dataset.ID,
+	}
+
+	return p
+}
+
+// CreateRangeSelectorPage ...
+func CreateRangeSelectorPage(name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset, nSelectors int) rangeSelector.Page {
+	var p rangeSelector.Page
+
+	p.SearchDisabled = true
+
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: dataset.Title,
+		URI:   fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", filter.Dataset, filter.Edition, filter.Version),
+	})
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: "Filter this dataset",
+		URI:   fmt.Sprintf("/filters/%s/dimensions", filter.FilterID),
+	})
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: dimensionTitleTranslator[name],
+	})
+
+	p.Data.Title = dimensionTitleTranslator[name]
+	p.FilterID = filter.FilterID
+
+	p.Data.AddFromList = rangeSelector.Link{
+		Label: fmt.Sprintf("Add %s range", name),
+		URL:   fmt.Sprintf("/filters/%s/dimensions/%s-list", filter.FilterID, name),
+	}
+	p.Data.AddRange = rangeSelector.Link{
+		Label: fmt.Sprintf("Add %ss", name),
+		URL:   fmt.Sprintf("/filters/%s/dimensions/%s/add", filter.FilterID, name),
+	}
+	p.Data.AddAllInRange = rangeSelector.Link{
+		Label: fmt.Sprintf("All %ss", name),
+	}
+	p.Data.AddNewRange = rangeSelector.Link{
+		URL: fmt.Sprintf("/filters/%s/dimensions/%s?nSelectors=%d", filter.FilterID, name, nSelectors+1),
+	}
+	p.Data.RemoveRange = rangeSelector.Link{
+		URL: fmt.Sprintf("/filters/%s/dimensions/%s?nSelectors=%d", filter.FilterID, name, nSelectors-1),
+	}
+	p.Data.SaveAndReturn = rangeSelector.Link{
+		URL: fmt.Sprintf("/filters/%s/dimensions", filter.FilterID),
+	}
+	p.Data.Cancel = rangeSelector.Link{
+		URL: fmt.Sprintf("/filters/%s/dimensions", filter.FilterID),
+	}
+	for _, val := range selectedValues.Items {
+		p.Data.FiltersAdded = append(p.Data.FiltersAdded, rangeSelector.Filter{
+			RemoveURL: fmt.Sprintf("/filters/%s/dimensions/%s/remove/%s", filter.FilterID, name, val.Name),
+			Label:     val.Name,
+		})
+	}
+
+	p.Data.FiltersAmount = len(selectedValues.Items)
+
+	for _, val := range allValues.Items {
+		p.Data.RangeData.Values = append(p.Data.RangeData.Values, val.Label)
+	}
+
+	p.Data.RangeData.StartLabel = "Start"
+	p.Data.RangeData.EndLabel = "End"
+	p.Data.RangeData.URL = fmt.Sprintf("/filters/%s/dimensions/%s/range", filter.FilterID, name)
+
+	p.Data.NumberOfSelectors = nSelectors + 1
 
 	p.Metadata.Footer = model.Footer{
 		Enabled:     true,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -82,6 +82,8 @@ func CreateFilterOverview(dimensions []data.Dimension, filter data.Filter, datas
 	return p
 }
 
+// CreateListSelectorPage maps items from API responses to form the model for a
+// dimension list selector page
 func CreateListSelectorPage(name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset) listSelector.Page {
 	var p listSelector.Page
 
@@ -174,7 +176,8 @@ func CreateListSelectorPage(name string, selectedValues, allValues data.Dimensio
 	return p
 }
 
-// CreateRangeSelectorPage ...
+// CreateRangeSelectorPage maps items from API responses to form a dimension range
+// selector page model
 func CreateRangeSelectorPage(name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset) rangeSelector.Page {
 	var p rangeSelector.Page
 
@@ -231,6 +234,10 @@ func CreateRangeSelectorPage(name string, selectedValues, allValues data.Dimensi
 	for _, val := range allValues.Items {
 		p.Data.RangeData.Values = append(p.Data.RangeData.Values, val.Label)
 	}
+
+	p.Data.RangeData.URL = fmt.Sprintf("/filters/%s/dimensions/%s/range", filter.FilterID, name)
+
+	p.Data.RemoveAll.URL = fmt.Sprintf("/filters/%s/dimensions/%s/remove-all", filter.FilterID, name)
 
 	p.Data.RangeData.StartLabel = "Start"
 	p.Data.RangeData.EndLabel = "End"

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -89,7 +89,7 @@ func CreateRangeSelectorPage(name string, selectedValues, allValues data.Dimensi
 
 	p.Data.AddFromList = rangeSelector.Link{
 		Label: fmt.Sprintf("Add %s range", name),
-		URL:   fmt.Sprintf("/filters/%s/dimensions/%s-list", filter.FilterID, name),
+		URL:   fmt.Sprintf("/filters/%s/dimensions/%s?selectorType=list", filter.FilterID, name),
 	}
 	p.Data.AddRange = rangeSelector.Link{
 		Label: fmt.Sprintf("Add %ss", name),

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -132,7 +132,7 @@ func CreateListSelectorPage(name string, selectedValues, allValues data.Dimensio
 }
 
 // CreateRangeSelectorPage ...
-func CreateRangeSelectorPage(name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset, nSelectors int) rangeSelector.Page {
+func CreateRangeSelectorPage(name string, selectedValues, allValues data.DimensionValues, filter data.Filter, dataset data.Dataset) rangeSelector.Page {
 	var p rangeSelector.Page
 
 	p.SearchDisabled = true
@@ -163,12 +163,6 @@ func CreateRangeSelectorPage(name string, selectedValues, allValues data.Dimensi
 	p.Data.AddAllInRange = rangeSelector.Link{
 		Label: fmt.Sprintf("All %ss", name),
 	}
-	p.Data.AddNewRange = rangeSelector.Link{
-		URL: fmt.Sprintf("/filters/%s/dimensions/%s?nSelectors=%d", filter.FilterID, name, nSelectors+1),
-	}
-	p.Data.RemoveRange = rangeSelector.Link{
-		URL: fmt.Sprintf("/filters/%s/dimensions/%s?nSelectors=%d", filter.FilterID, name, nSelectors-1),
-	}
 	p.Data.SaveAndReturn = rangeSelector.Link{
 		URL: fmt.Sprintf("/filters/%s/dimensions", filter.FilterID),
 	}
@@ -191,8 +185,6 @@ func CreateRangeSelectorPage(name string, selectedValues, allValues data.Dimensi
 	p.Data.RangeData.StartLabel = "Start"
 	p.Data.RangeData.EndLabel = "End"
 	p.Data.RangeData.URL = fmt.Sprintf("/filters/%s/dimensions/%s/range", filter.FilterID, name)
-
-	p.Data.NumberOfSelectors = nSelectors + 1
 
 	p.Metadata.Footer = model.Footer{
 		Enabled:     true,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -17,7 +17,7 @@ func TestUnitMapper(t *testing.T) {
 		fop := CreateFilterOverview(dimensions, filter, dataset, filter.FilterID)
 		So(fop.FilterID, ShouldEqual, filter.FilterID)
 		So(fop.SearchDisabled, ShouldBeTrue)
-		So(fop.Data.Dimensions, ShouldHaveLength, 4)
+		So(fop.Data.Dimensions, ShouldHaveLength, 5)
 		So(fop.Data.Dimensions[0].Filter, ShouldEqual, "Year")
 		So(fop.Data.Dimensions[0].AddedCategories[0], ShouldEqual, "2014")
 		So(fop.Data.Dimensions[0].Link.Label, ShouldEqual, "Filter")
@@ -75,6 +75,122 @@ func TestUnitMapper(t *testing.T) {
 			So(dim, ShouldResemble, previewPage.Dimension(dimensions[i]))
 		}
 	})
+
+	Convey("test CreateListSelector page correctly maps to listSelector frontend model", t, func() {
+		filter := getTestFilter()
+		dataset := getTestDataset()
+		selectedValues := data.DimensionValues{
+			Items: []data.DimensionValueItem{
+				{
+					Name: "2010.02",
+					ID:   "abcdefg",
+				},
+			},
+			NumberOfResults: 1,
+		}
+		allValues := data.DimensionValues{
+			Items: []data.DimensionValueItem{
+				{
+					Label: "2010.02",
+					ID:    "abcdefg",
+				},
+				{
+					Label: "2010.03",
+					ID:    "38jd83ik",
+				},
+				{
+					Label: "2010.04",
+					ID:    "13984094",
+				},
+			},
+			NumberOfResults: 1,
+		}
+
+		p := CreateListSelectorPage("time", selectedValues, allValues, filter, dataset)
+		So(p.Data.Title, ShouldEqual, "Time")
+		So(p.SearchDisabled, ShouldBeTrue)
+		So(p.FilterID, ShouldEqual, filter.FilterID)
+
+		So(p.Breadcrumb, ShouldHaveLength, 3)
+		So(p.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
+		So(p.Breadcrumb[0].URI, ShouldEqual, "/datasets/"+filter.Dataset+"/editions/"+filter.Edition+"/versions/"+filter.Version)
+		So(p.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
+		So(p.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Breadcrumb[2].Title, ShouldEqual, "Time")
+		So(p.Data.AddFromRange.Label, ShouldEqual, "add time range")
+		So(p.Data.AddFromRange.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time")
+		So(p.Data.SaveAndReturn.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Data.Cancel.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Data.AddAllInRange.Label, ShouldEqual, "All times")
+		So(p.Data.RangeData.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/list")
+		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all")
+		So(p.Data.RangeData.Values, ShouldHaveLength, 3)
+		So(p.Data.RangeData.Values[0].Label, ShouldEqual, "February 2010")
+		So(p.Data.RangeData.Values[0].IsSelected, ShouldBeTrue)
+		So(p.Data.RangeData.Values[1].Label, ShouldEqual, "March 2010")
+		So(p.Data.RangeData.Values[1].IsSelected, ShouldBeFalse)
+		So(p.Data.RangeData.Values[2].Label, ShouldEqual, "April 2010")
+		So(p.Data.RangeData.Values[2].IsSelected, ShouldBeFalse)
+		So(p.Data.FiltersAmount, ShouldEqual, 1)
+		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
+		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, dataset.ReleaseDate)
+		So(p.Metadata.Footer.DatasetID, ShouldEqual, dataset.ID)
+	})
+
+	Convey("test CreateRangeSelectorPage successfully maps to a rangeSelector page model", t, func() {
+		filter := getTestFilter()
+		dataset := getTestDataset()
+		selectedValues := data.DimensionValues{
+			Items: []data.DimensionValueItem{
+				{
+					Name: "2010.02",
+					ID:   "abcdefg",
+				},
+			},
+			NumberOfResults: 1,
+		}
+		allValues := data.DimensionValues{
+			Items: []data.DimensionValueItem{
+				{
+					Label: "2010.02",
+					ID:    "abcdefg",
+				},
+				{
+					Label: "2010.03",
+					ID:    "38jd83ik",
+				},
+				{
+					Label: "2010.04",
+					ID:    "13984094",
+				},
+			},
+			NumberOfResults: 1,
+		}
+
+		p := CreateRangeSelectorPage("time", selectedValues, allValues, filter, dataset)
+		So(p.Data.Title, ShouldEqual, "Time")
+		So(p.SearchDisabled, ShouldBeTrue)
+		So(p.FilterID, ShouldEqual, filter.FilterID)
+
+		So(p.Breadcrumb, ShouldHaveLength, 3)
+		So(p.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
+		So(p.Breadcrumb[0].URI, ShouldEqual, "/datasets/"+filter.Dataset+"/editions/"+filter.Edition+"/versions/"+filter.Version)
+		So(p.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
+		So(p.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Breadcrumb[2].Title, ShouldEqual, "Time")
+		So(p.Data.AddFromList.Label, ShouldEqual, "Add time range")
+		So(p.Data.AddFromList.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time?selectorType=list")
+		So(p.Data.SaveAndReturn.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Data.Cancel.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
+		So(p.Data.AddAllInRange.Label, ShouldEqual, "All times")
+		So(p.Data.RangeData.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/range")
+		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all")
+		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
+		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, dataset.ReleaseDate)
+		So(p.Metadata.Footer.DatasetID, ShouldEqual, dataset.ID)
+	})
 }
 
 func getTestDimensions() []data.Dimension {
@@ -94,6 +210,10 @@ func getTestDimensions() []data.Dimension {
 		{
 			Name:   "age-range",
 			Values: []string{"0 - 92", "2 - 18", "18 - 65"},
+		},
+		{
+			Name:   "time",
+			Values: []string{"2002.10", "2009.08", "1996.08"},
 		},
 	}
 }

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "start",
+    "rules": [
+      {
+        "name": "min_length",
+        "value": 1
+      }
+    ]
+  },
+  {
+    "id": "end",
+    "rules": [
+      {
+        "name": "min_length",
+        "value": 1
+      }
+    ]
+  }
+]

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
@@ -1,0 +1,43 @@
+package listSelector
+
+import "github.com/ONSdigital/dp-frontend-models/model"
+
+// Page ...
+type Page struct {
+	model.Page
+	Data     ListSelector `json:"data"`
+	FilterID string       `json:"job_id"`
+}
+
+// ListSelector ...
+type ListSelector struct {
+	AddFromRange  Link     `json:"add_from_range"`
+	SaveAndReturn Link     `json:"save_and_return"`
+	Cancel        Link     `json:"cancel"`
+	FiltersAmount int      `json:"filters_amount"`
+	FiltersAdded  []Filter `json:"filters_added"`
+	AddAllInRange Link     `json:"add_all"`
+	RemoveAll     Link     `json:"remove_all"`
+	RangeData     Range    `json:"range_values"`
+}
+
+// Link ...
+type Link struct {
+	URL   string `json:"url"`
+	Label string `json:"label"`
+}
+
+// Filter ...
+type Filter struct {
+	Label     string `json:"label"`
+	RemoveURL string `json:"remove_url"`
+}
+
+// Range ...
+type Range struct {
+	StartNum     int    `json:"start_num"`
+	EndNum       int    `json:"end_num"`
+	StartLabel   string `json:"start_label"`
+	EndLabel     string `json:"end_label"`
+	AppendString string `json:"append_string"`
+}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
@@ -35,9 +35,12 @@ type Filter struct {
 
 // Range ...
 type Range struct {
-	StartNum     int    `json:"start_num"`
-	EndNum       int    `json:"end_num"`
-	StartLabel   string `json:"start_label"`
-	EndLabel     string `json:"end_label"`
-	AppendString string `json:"append_string"`
+	URL    string  `json:"url"`
+	Values []Value `json:"values"`
+}
+
+// Value ...
+type Value struct {
+	Label      string `json:"label"`
+	IsSelected bool   `json:"is_selected"`
 }

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector/list-selector.go
@@ -11,6 +11,7 @@ type Page struct {
 
 // ListSelector ...
 type ListSelector struct {
+	Title         string   `json:"title"`
 	AddFromRange  Link     `json:"add_from_range"`
 	SaveAndReturn Link     `json:"save_and_return"`
 	Cancel        Link     `json:"cancel"`

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
@@ -5,7 +5,8 @@ import "github.com/ONSdigital/dp-frontend-models/model"
 // Page ...
 type Page struct {
 	model.Page
-	Data PreviewPage `json:"data"`
+	Data            PreviewPage `json:"data"`
+	IsContentLoaded bool        `json:"is_content_loaded"`
 }
 
 // PreviewPage ...

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
@@ -11,6 +11,7 @@ type Page struct {
 
 // RangeSelector ...
 type RangeSelector struct {
+	Title             string   `json:"title"`
 	AddFromList       Link     `json:"add_from_list"`
 	NumberOfSelectors int      `json:"num_of_selectors"`
 	AddAllInRange     Link     `json:"add_all"`
@@ -39,9 +40,8 @@ type Filter struct {
 
 // Range ...
 type Range struct {
-	StartNum     int    `json:"start_num"`
-	EndNum       int    `json:"end_num"`
-	StartLabel   string `json:"start_label"`
-	EndLabel     string `json:"end_label"`
-	AppendString string `json:"append_string"`
+	URL        string   `json:"url"`
+	Values     []string `json:"values"`
+	StartLabel string   `json:"start_label"`
+	EndLabel   string   `json:"end_label"`
 }

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
@@ -5,15 +5,16 @@ import "github.com/ONSdigital/dp-frontend-models/model"
 // Page ...
 type Page struct {
 	model.Page
-	Data     rangeSelector `json:"data"`
-	FilterID string           `json:"filter_id"`
+	Data     RangeSelector `json:"data"`
+	FilterID string        `json:"job_id"`
 }
 
-// rangeSelector ...
-type rangeSelector struct {
+// RangeSelector ...
+type RangeSelector struct {
 	AddFromList       Link     `json:"add_from_list"`
 	NumberOfSelectors int      `json:"num_of_selectors"`
-	AddAges           Link     `json:"add_ages"`
+	AddAllInRange     Link     `json:"add_all"`
+	AddRange          Link     `json:"add_range"`
 	AddNewRange       Link     `json:"add_new_range"`
 	RemoveRange       Link     `json:"remove_range"`
 	SaveAndReturn     Link     `json:"save_and_return"`
@@ -21,7 +22,7 @@ type rangeSelector struct {
 	FiltersAmount     int      `json:"filters_amount"`
 	FiltersAdded      []Filter `json:"filters_added"`
 	RemoveAll         Link     `json:"remove_all"`
-	AgeRange          Range    `json:"age_range"`
+	RangeData         Range    `json:"range_values"`
 }
 
 // Link ...
@@ -38,6 +39,9 @@ type Filter struct {
 
 // Range ...
 type Range struct {
-	StartNum int `json:"start_num"`
-	EndNum   int `json:"end_num"`
+	StartNum     int    `json:"start_num"`
+	EndNum       int    `json:"end_num"`
+	StartLabel   string `json:"start_label"`
+	EndLabel     string `json:"end_label"`
+	AppendString string `json:"append_string"`
 }

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector/range-selector.go
@@ -6,24 +6,21 @@ import "github.com/ONSdigital/dp-frontend-models/model"
 type Page struct {
 	model.Page
 	Data     RangeSelector `json:"data"`
-	FilterID string        `json:"job_id"`
+	FilterID string        `json:"filter_id"`
 }
 
 // RangeSelector ...
 type RangeSelector struct {
-	Title             string   `json:"title"`
-	AddFromList       Link     `json:"add_from_list"`
-	NumberOfSelectors int      `json:"num_of_selectors"`
-	AddAllInRange     Link     `json:"add_all"`
-	AddRange          Link     `json:"add_range"`
-	AddNewRange       Link     `json:"add_new_range"`
-	RemoveRange       Link     `json:"remove_range"`
-	SaveAndReturn     Link     `json:"save_and_return"`
-	Cancel            Link     `json:"cancel"`
-	FiltersAmount     int      `json:"filters_amount"`
-	FiltersAdded      []Filter `json:"filters_added"`
-	RemoveAll         Link     `json:"remove_all"`
-	RangeData         Range    `json:"range_values"`
+	Title         string   `json:"title"`
+	AddFromList   Link     `json:"add_from_list"`
+	AddAllInRange Link     `json:"add_all"`
+	AddRange      Link     `json:"add_range"`
+	SaveAndReturn Link     `json:"save_and_return"`
+	Cancel        Link     `json:"cancel"`
+	FiltersAmount int      `json:"filters_amount"`
+	FiltersAdded  []Filter `json:"filters_added"`
+	RemoveAll     Link     `json:"remove_all"`
+	RangeData     Range    `json:"range_values"`
 }
 
 // Link ...

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,6 +27,12 @@
 			"revisionTime": "2017-07-18T12:33:43Z"
 		},
 		{
+			"checksumSHA1": "r/LSqsdB2RSCdmWfT5v0zoo2D+Y=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector",
+			"revision": "6b06fdb89299c5c6534f46d661a27e5b52366a09",
+			"revisionTime": "2017-07-31T13:06:09Z"
+		},
+		{
 			"checksumSHA1": "XiB1eoyvRBkRzkGyrjjJwsXA+Go=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
 			"revision": "87180bd5ba6e86bf6e1d756daaedd77ef3acd72d",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-07-24T10:41:27Z"
 		},
 		{
-			"checksumSHA1": "Qobw+xRyZRC3Xne7hT+Sp+j8VVM=",
+			"checksumSHA1": "SQC1OKjuwXmzbK2yHsSQUdEPNVg=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector",
-			"revision": "5e736eb8594125cec81f10b27705395a5adfaa53",
-			"revisionTime": "2017-07-11T14:39:42Z"
+			"revision": "3320ffe857bfbbcdd5c9ab89053e2d34159c60cd",
+			"revisionTime": "2017-08-01T07:56:40Z"
 		},
 		{
 			"checksumSHA1": "fAyPS71FyNTWhcs+JmSkZupUaeE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-07-31T13:06:09Z"
 		},
 		{
-			"checksumSHA1": "XiB1eoyvRBkRzkGyrjjJwsXA+Go=",
+			"checksumSHA1": "sHDodVbm939D/6IsVUko8Lq8Sqo=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
-			"revision": "87180bd5ba6e86bf6e1d756daaedd77ef3acd72d",
-			"revisionTime": "2017-07-24T10:41:27Z"
+			"revision": "8e300e8e9b6b70e4ac92de84cf8f42cdbd65478c",
+			"revisionTime": "2017-08-01T11:06:59Z"
 		},
 		{
 			"checksumSHA1": "SQC1OKjuwXmzbK2yHsSQUdEPNVg=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-08-01T11:06:59Z"
 		},
 		{
-			"checksumSHA1": "SQC1OKjuwXmzbK2yHsSQUdEPNVg=",
+			"checksumSHA1": "PNDiOZAMkjc7uuR3n74Y1xvRP50=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector",
-			"revision": "3320ffe857bfbbcdd5c9ab89053e2d34159c60cd",
-			"revisionTime": "2017-08-01T07:56:40Z"
+			"revision": "a066a96864df2e5b4b98d3867a26c476d613e645",
+			"revisionTime": "2017-08-02T14:32:41Z"
 		},
 		{
 			"checksumSHA1": "fAyPS71FyNTWhcs+JmSkZupUaeE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2017-07-18T12:33:43Z"
 		},
 		{
-			"checksumSHA1": "r/LSqsdB2RSCdmWfT5v0zoo2D+Y=",
+			"checksumSHA1": "eLlYioQeFVyHBe3sH+kRlDoEf4U=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector",
-			"revision": "6b06fdb89299c5c6534f46d661a27e5b52366a09",
-			"revisionTime": "2017-07-31T13:06:09Z"
+			"revision": "2c25a736661c902a9d24197ca13d5934fa23836b",
+			"revisionTime": "2017-08-02T11:37:15Z"
 		},
 		{
 			"checksumSHA1": "sHDodVbm939D/6IsVUko8Lq8Sqo=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,7 +27,7 @@
 			"revisionTime": "2017-07-18T12:33:43Z"
 		},
 		{
-			"checksumSHA1": "eLlYioQeFVyHBe3sH+kRlDoEf4U=",
+			"checksumSHA1": "HN/HL0o8Ep+mcd009giqwwxo6rI=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/listSelector",
 			"revision": "2c25a736661c902a9d24197ca13d5934fa23836b",
 			"revisionTime": "2017-08-02T11:37:15Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,12 +15,6 @@
 			"revisionTime": "2017-07-18T12:33:43Z"
 		},
 		{
-			"checksumSHA1": "S9OZrmzfuejsxhrtc0CLwiSFLz4=",
-			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/ageSelectorRange",
-			"revision": "fd87760f288b942010fdb9db9ae9ffe91212ad36",
-			"revisionTime": "2017-07-18T12:33:43Z"
-		},
-		{
 			"checksumSHA1": "qVbLrqNkeYuRauL+C7MharQ1REs=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview",
 			"revision": "fd87760f288b942010fdb9db9ae9ffe91212ad36",
@@ -37,6 +31,12 @@
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
 			"revision": "87180bd5ba6e86bf6e1d756daaedd77ef3acd72d",
 			"revisionTime": "2017-07-24T10:41:27Z"
+		},
+		{
+			"checksumSHA1": "Qobw+xRyZRC3Xne7hT+Sp+j8VVM=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/rangeSelector",
+			"revision": "5e736eb8594125cec81f10b27705395a5adfaa53",
+			"revisionTime": "2017-07-11T14:39:42Z"
 		},
 		{
 			"checksumSHA1": "fAyPS71FyNTWhcs+JmSkZupUaeE=",


### PR DESCRIPTION
### What

Add the ability to select a time dimension on the CMD journey for CPI and then navigate through the dimension and add/remove values. Note that this uses stubbed versions of the Filter/Dataset apis and may need further integration when plugging in to real versions.

### How to review

Start the usual services for CMD with the feature/time-dimension branches checked out on the filter-dataset-controller and renderer. You will also need the codelist-api checked out on master as well as cloning this repo https://github.com/mattrout92/stubbed-apis and running the stubbed filter and dataset apis based on the current state of the specs.

Once you have all these services running you should be able to navigate through the time dimension by going to http://localhost:20000/filters/12327673/dimensions and choosing time! Note these fields will not dynamically update until the real apis are plugged in.

### Who can review

Frontend dev