### PR TITLE
Unstub dimensions and use latest filter api spec

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tags: 1.8.3
+    tags: 1.9.0
 
 inputs:
   - name: dp-frontend-filter-dataset-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.8.3
+    tag: 1.9.0
 
 inputs:
   - name: dp-frontend-filter-dataset-controller

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -2,7 +2,6 @@ package dates
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"time"
 )
@@ -27,15 +26,11 @@ func (p TimeSlice) Swap(i, j int) {
 func ConvertToReadable(dates []string) ([]time.Time, error) {
 	var readableDates []time.Time
 	for _, val := range dates {
-		myrReg := regexp.MustCompile(`^(\d{4})\.(\d{1}|\d{2})$`)
-		myrSubs := myrReg.FindStringSubmatch(val)
-		if len(myrSubs) == 3 {
-			date, err := time.Parse("01-02-2006", fmt.Sprintf("%02s-01-%s", myrSubs[2], myrSubs[1]))
-			if err != nil {
-				return readableDates, err
-			}
-			readableDates = append(readableDates, date)
+		date, err := time.Parse("Jan-06", val)
+		if err != nil {
+			return readableDates, err
 		}
+		readableDates = append(readableDates, date)
 	}
 
 	return readableDates, nil
@@ -59,7 +54,7 @@ func Sort(dates []time.Time) TimeSlice {
 func ConvertToCoded(dates []time.Time) []string {
 	var codedDates []string
 	for _, date := range dates {
-		codedDates = append(codedDates, fmt.Sprintf("%d.%02d", date.Year(), date.Month()))
+		codedDates = append(codedDates, date.Format("Jan-06"))
 	}
 
 	return codedDates

--- a/dates/dates_test.go
+++ b/dates/dates_test.go
@@ -10,7 +10,7 @@ import (
 func TestUnitDates(t *testing.T) {
 	Convey("test ConvertToReadable", t, func() {
 		Convey("converts a string slice with values in the format `yyyy.mm` to time.Time slice", func() {
-			times, err := ConvertToReadable([]string{"2006.05"})
+			times, err := ConvertToReadable([]string{"May-06"})
 			So(err, ShouldBeNil)
 			So(times, ShouldHaveLength, 1)
 			So(times[0].Month().String(), ShouldEqual, "May")
@@ -18,7 +18,7 @@ func TestUnitDates(t *testing.T) {
 		})
 
 		Convey("test error thrown if unable to parse date", func() {
-			times, err := ConvertToReadable([]string{"2010.13"})
+			times, err := ConvertToReadable([]string{"Nop-13"})
 			So(err, ShouldNotBeNil)
 			So(times, ShouldBeEmpty)
 		})
@@ -47,8 +47,8 @@ func TestUnitDates(t *testing.T) {
 		time3, _ := time.Parse("01-02-2006", "10-01-2006")
 
 		codedDates := ConvertToCoded([]time.Time{time1, time2, time3})
-		So(codedDates[0], ShouldEqual, "2006.07")
-		So(codedDates[1], ShouldEqual, "2006.02")
-		So(codedDates[2], ShouldEqual, "2006.10")
+		So(codedDates[0], ShouldEqual, "Jul-06")
+		So(codedDates[1], ShouldEqual, "Feb-06")
+		So(codedDates[2], ShouldEqual, "Oct-06")
 	})
 }

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -31,6 +31,8 @@ type DatasetClient interface {
 	GetEditions(id string) (m []dataset.Edition, err error)
 	GetVersions(id, edition string) (m []dataset.Version, err error)
 	GetVersion(id, edition, version string) (m dataset.Version, err error)
+	GetDimensions(id, edition, version string) (m dataset.Dimensions, err error)
+	GetOptions(id, edition, version, dimension string) (m dataset.Options, err error)
 }
 
 // CodelistClient contains methods expected for a codelist client

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -87,13 +87,6 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 
-	filter, err := f.FilterClient.GetJobState(filterID)
-	if err != nil {
-		log.ErrorR(req, err, nil)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	dataset, err := f.DatasetClient.Get(datasetID)
 	if err != nil {
 		log.Error(err, nil)
@@ -114,7 +107,7 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateFilterOverview(dimensions, filter, dataset, filterID, datasetID, ver.ReleaseDate)
+	p := mapper.CreateFilterOverview(dimensions, fj, dataset, filterID, datasetID, ver.ReleaseDate)
 
 	if latestURL.Path == versionURL.Path {
 		p.Data.IsLatestVersion = true

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -26,24 +26,45 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	codeID := "64d384f1-ea3b-445c-8fb8-aa453f96e58a" // time
-	idNameLookup, err := f.CodeListClient.GetIDNameMap(codeID)
+	fj, err := f.FilterClient.GetJobState(filterID)
 	if err != nil {
 		log.ErrorR(req, err, nil)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	codeID = "e44de4c4-d39e-4e2f-942b-3ca10584d078" // goods-and-services
-	map2, err := f.CodeListClient.GetIDNameMap(codeID)
+	versionURL, err := url.Parse(fj.Links.Version.HRef)
 	if err != nil {
 		log.ErrorR(req, err, nil)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	if err != nil {
+		log.Error(err, nil)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	for k, v := range map2 {
-		idNameLookup[k] = v
+	datasetDimensions, err := f.DatasetClient.GetDimensions(datasetID, edition, version)
+	if err != nil {
+		log.Error(err, nil)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	idNameLookup := make(map[string]string)
+	for _, dim := range datasetDimensions.Items {
+		options, err := f.DatasetClient.GetOptions(datasetID, edition, version, dim.ID)
+		if err != nil {
+			log.ErrorR(req, err, nil)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		for _, opt := range options.Items {
+			idNameLookup[opt.Option] = opt.Label
+		}
 	}
 
 	var dimensions []filter.ModelDimension
@@ -73,14 +94,6 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	//versionURL := filter.DatasetFilterID
-	versionURL := "/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(versionURL)
-	if err != nil {
-		log.Error(err, nil)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 	dataset, err := f.DatasetClient.Get(datasetID)
 	if err != nil {
 		log.Error(err, nil)
@@ -103,11 +116,11 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 
 	p := mapper.CreateFilterOverview(dimensions, filter, dataset, filterID, datasetID, ver.ReleaseDate)
 
-	if latestURL.Path == versionURL {
+	if latestURL.Path == versionURL.Path {
 		p.Data.IsLatestVersion = true
 	}
 
-	p.Data.LatestVersion.DatasetLandingPageURL = versionURL
+	p.Data.LatestVersion.DatasetLandingPageURL = versionURL.Path
 	p.Data.LatestVersion.FilterJourneyWithLatestJourney = fmt.Sprintf("/filters/%s/use-latest-version", filterID)
 
 	b, err := json.Marshal(p)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ONSdigital/go-ns/clients/dataset"
+	dataset "github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/clients/filter"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
@@ -21,10 +21,9 @@ func TestUnitFilterOverview(t *testing.T) {
 		Convey("test FilterOverview can successfully load a page", func() {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
 			mockFilterClient.EXPECT().GetDimensions("12345").Return([]filter.Dimension{filter.Dimension{Name: "Day"}, filter.Dimension{Name: "Goods and Services"}}, nil)
-			mockCodeListClient := NewMockCodelistClient(mockCtrl)
 			mockFilterClient.EXPECT().GetDimensionOptions("12345", "Day").Return([]filter.DimensionOption{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions("12345", "Goods and Services").Return([]filter.DimensionOption{}, nil)
-			mockFilterClient.EXPECT().GetJobState("12345").Return(filter.Model{DatasetFilterID: "/datasets/12345/editions/2016/versions/1"}, nil)
+			mockFilterClient.EXPECT().GetJobState("12345").Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetDimensions("95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Dimensions{Items: []dataset.Dimension{{ID: "geography"}}}, nil)
 			mockDatasetClient.EXPECT().GetOptions("95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography")
@@ -37,7 +36,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, mockCodeListClient, nil, nil)
+			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil)
 			router.Path("/filters/{filterID}/dimensions").HandlerFunc(f.FilterOverview)
 
 			router.ServeHTTP(w, req)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	dataset "github.com/ONSdigital/go-ns/clients/dataset"
+	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/clients/filter"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
@@ -22,17 +22,13 @@ func TestUnitFilterOverview(t *testing.T) {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
 			mockFilterClient.EXPECT().GetDimensions("12345").Return([]filter.Dimension{filter.Dimension{Name: "Day"}, filter.Dimension{Name: "Goods and Services"}}, nil)
 			mockCodeListClient := NewMockCodelistClient(mockCtrl)
-			mockCodeListClient.EXPECT().GetIDNameMap("64d384f1-ea3b-445c-8fb8-aa453f96e58a").Return(map[string]string{
-				"1234567": "Monday",
-			}, nil)
-			mockCodeListClient.EXPECT().GetIDNameMap("e44de4c4-d39e-4e2f-942b-3ca10584d078").Return(map[string]string{
-				"678910": "Travel",
-			}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions("12345", "Day").Return([]filter.DimensionOption{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions("12345", "Goods and Services").Return([]filter.DimensionOption{}, nil)
 			mockFilterClient.EXPECT().GetJobState("12345").Return(filter.Model{DatasetFilterID: "/datasets/12345/editions/2016/versions/1"}, nil)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
-			mockDatasetClient.EXPECT().Get("95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.Model{}, nil)
+			mockDatasetClient.EXPECT().GetDimensions("95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Dimensions{Items: []dataset.Dimension{{ID: "geography"}}}, nil)
+			mockDatasetClient.EXPECT().GetOptions("95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography")
+			mockDatasetClient.EXPECT().Get("95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.Model{Contacts: []dataset.Contact{{Name: "Matt"}}}, nil)
 			mockDatasetClient.EXPECT().GetVersion("95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Version{}, nil)
 			mockRenderer := NewMockRenderer(mockCtrl)
 			mockRenderer.EXPECT().Do("dataset-filter/filter-overview", gomock.Any()).Return([]byte("some-bytes"), nil)

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -220,6 +220,19 @@ func (_mr *MockDatasetClientMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0)
 }
 
+// GetDimensions mocks base method
+func (_m *MockDatasetClient) GetDimensions(_param0 string, _param1 string, _param2 string) (dataset.Dimensions, error) {
+	ret := _m.ctrl.Call(_m, "GetDimensions", _param0, _param1, _param2)
+	ret0, _ := ret[0].(dataset.Dimensions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDimensions indicates an expected call of GetDimensions
+func (_mr *MockDatasetClientMockRecorder) GetDimensions(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDimensions", arg0, arg1, arg2)
+}
+
 // GetEditions mocks base method
 func (_m *MockDatasetClient) GetEditions(_param0 string) ([]dataset.Edition, error) {
 	ret := _m.ctrl.Call(_m, "GetEditions", _param0)
@@ -231,6 +244,19 @@ func (_m *MockDatasetClient) GetEditions(_param0 string) ([]dataset.Edition, err
 // GetEditions indicates an expected call of GetEditions
 func (_mr *MockDatasetClientMockRecorder) GetEditions(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetEditions", arg0)
+}
+
+// GetOptions mocks base method
+func (_m *MockDatasetClient) GetOptions(_param0 string, _param1 string, _param2 string, _param3 string) (dataset.Options, error) {
+	ret := _m.ctrl.Call(_m, "GetOptions", _param0, _param1, _param2, _param3)
+	ret0, _ := ret[0].(dataset.Options)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOptions indicates an expected call of GetOptions
+func (_mr *MockDatasetClientMockRecorder) GetOptions(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOptions", arg0, arg1, arg2, arg3)
 }
 
 // GetVersion mocks base method

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -41,7 +41,6 @@ func TestUnitMapper(t *testing.T) {
 		So(fop.Data.Cancel.URL, ShouldEqual, "/")
 		So(fop.Breadcrumb, ShouldHaveLength, 2)
 		So(fop.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
-		So(fop.Breadcrumb[0].URI, ShouldEqual, filter.DatasetFilterID)
 		So(fop.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
 		So(fop.Metadata.Footer.Enabled, ShouldBeTrue)
 		So(fop.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
@@ -58,7 +57,6 @@ func TestUnitMapper(t *testing.T) {
 		So(pp.SearchDisabled, ShouldBeTrue)
 		So(pp.Breadcrumb, ShouldHaveLength, 3)
 		So(pp.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
-		So(pp.Breadcrumb[0].URI, ShouldEqual, filter.DatasetFilterID)
 		So(pp.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
 		So(pp.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(pp.Breadcrumb[2].Title, ShouldEqual, "Preview")
@@ -113,7 +111,6 @@ func TestUnitMapper(t *testing.T) {
 
 		So(p.Breadcrumb, ShouldHaveLength, 3)
 		So(p.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
-		So(p.Breadcrumb[0].URI, ShouldEqual, filter.DatasetFilterID)
 		So(p.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
 		So(p.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(p.Breadcrumb[2].Title, ShouldEqual, "Time")
@@ -175,7 +172,6 @@ func TestUnitMapper(t *testing.T) {
 
 		So(p.Breadcrumb, ShouldHaveLength, 3)
 		So(p.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
-		So(p.Breadcrumb[0].URI, ShouldEqual, filter.DatasetFilterID)
 		So(p.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
 		So(p.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(p.Breadcrumb[2].Title, ShouldEqual, "Time")
@@ -220,11 +216,15 @@ func getTestDimensions() []filter.ModelDimension {
 
 func getTestFilter() filter.Model {
 	return filter.Model{
-		FilterID:        "12349876",
-		DatasetFilterID: "/filters/12345/editions/2016/versions/1",
-		Edition:         "12345",
-		Dataset:         "849209",
-		Version:         "2017",
+		FilterID: "12349876",
+		Edition:  "12345",
+		Dataset:  "849209",
+		Version:  "2017",
+		Links: filter.Links{
+			Version: filter.Link{
+				HRef: "/datasets/1234/editions/5678/versions/1",
+			},
+		},
 		Downloads: map[string]filter.Download{
 			"csv": {
 				Size: "362783",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -3,7 +3,6 @@ package mapper
 import (
 	"testing"
 
-	"github.com/ONSdigital/go-ns/clients/codelist"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/clients/filter"
 	. "github.com/smartystreets/goconvey/convey"
@@ -45,7 +44,7 @@ func TestUnitMapper(t *testing.T) {
 		So(fop.Breadcrumb[0].URI, ShouldEqual, filter.DatasetFilterID)
 		So(fop.Breadcrumb[1].Title, ShouldEqual, "Filter this dataset")
 		So(fop.Metadata.Footer.Enabled, ShouldBeTrue)
-		So(fop.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(fop.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
 		So(fop.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")
 		So(fop.Metadata.Footer.DatasetID, ShouldEqual, "12345")
 	})
@@ -65,7 +64,7 @@ func TestUnitMapper(t *testing.T) {
 		So(pp.Breadcrumb[2].Title, ShouldEqual, "Preview")
 		So(pp.Data.FilterID, ShouldEqual, filter.FilterID)
 		So(pp.Metadata.Footer.Enabled, ShouldBeTrue)
-		So(pp.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(pp.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
 		So(pp.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")
 		So(pp.Metadata.Footer.DatasetID, ShouldEqual, "12345")
 		So(pp.Data.Downloads[0].Extension, ShouldEqual, "csv")
@@ -79,6 +78,22 @@ func TestUnitMapper(t *testing.T) {
 	})
 
 	Convey("test CreateListSelector page correctly maps to listSelector frontend model", t, func() {
+		allValues := dataset.Options{
+			Items: []dataset.Option{
+				{
+					Label:  "Feb-10",
+					Option: "abcdefg",
+				},
+				{
+					Label:  "Mar-10",
+					Option: "38jd83ik",
+				},
+				{
+					Label:  "Apr-10",
+					Option: "13984094",
+				},
+			},
+		}
 		dataset := getTestDataset()
 		selectedValues := []filter.DimensionOption{
 			{
@@ -90,23 +105,6 @@ func TestUnitMapper(t *testing.T) {
 		}
 
 		filter := getTestFilter()
-		allValues := codelist.DimensionValues{
-			Items: []codelist.Item{
-				{
-					Label: "2010.02",
-					ID:    "abcdefg",
-				},
-				{
-					Label: "2010.03",
-					ID:    "38jd83ik",
-				},
-				{
-					Label: "2010.04",
-					ID:    "13984094",
-				},
-			},
-			NumberOfResults: 1,
-		}
 
 		p := CreateListSelectorPage("time", selectedValues, allValues, filter, dataset, "12345", "11-11-1992")
 		So(p.Data.Title, ShouldEqual, "Time")
@@ -135,12 +133,29 @@ func TestUnitMapper(t *testing.T) {
 		So(p.Data.RangeData.Values[2].IsSelected, ShouldBeFalse)
 		So(p.Data.FiltersAmount, ShouldEqual, 2)
 		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
-		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
 		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")
 		So(p.Metadata.Footer.DatasetID, ShouldEqual, "12345")
 	})
 
 	Convey("test CreateRangeSelectorPage successfully maps to a rangeSelector page model", t, func() {
+
+		allValues := dataset.Options{
+			Items: []dataset.Option{
+				{
+					Label:  "Feb-10",
+					Option: "abcdefg",
+				},
+				{
+					Label:  "Mar-10",
+					Option: "38jd83ik",
+				},
+				{
+					Label:  "Apr-10",
+					Option: "13984094",
+				},
+			},
+		}
 		dataset := getTestDataset()
 		selectedValues := []filter.DimensionOption{
 			{
@@ -152,23 +167,6 @@ func TestUnitMapper(t *testing.T) {
 		}
 
 		filter := getTestFilter()
-		allValues := codelist.DimensionValues{
-			Items: []codelist.Item{
-				{
-					Label: "2010.02",
-					ID:    "abcdefg",
-				},
-				{
-					Label: "2010.03",
-					ID:    "38jd83ik",
-				},
-				{
-					Label: "2010.04",
-					ID:    "13984094",
-				},
-			},
-			NumberOfResults: 1,
-		}
 
 		p := CreateRangeSelectorPage("time", selectedValues, allValues, filter, dataset, "12345", "11-11-1992")
 		So(p.Data.Title, ShouldEqual, "Time")
@@ -189,7 +187,7 @@ func TestUnitMapper(t *testing.T) {
 		So(p.Data.RangeData.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/range")
 		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all")
 		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
-		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contact.Name)
+		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
 		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")
 		So(p.Metadata.Footer.DatasetID, ShouldEqual, "12345")
 	})
@@ -243,10 +241,12 @@ func getTestFilter() filter.Model {
 func getTestDataset() dataset.Model {
 	return dataset.Model{
 		NextRelease: "17 January 2018",
-		Contact: dataset.Contact{
-			Name:      "Matt Rout",
-			Telephone: "07984593234",
-			Email:     "matt@gmail.com",
+		Contacts: []dataset.Contact{
+			{
+				Name:      "Matt Rout",
+				Telephone: "07984593234",
+				Email:     "matt@gmail.com",
+			},
 		},
 		Title: "Small Area Population Estimates",
 	}

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -3,7 +3,7 @@ package dataset
 // Model represents a response dataset model from the dataset api
 type Model struct {
 	CollectionID string    `json:"collection_id"`
-	Contact      Contact   `json:"contact"`
+	Contacts     []Contact `json:"contacts"`
 	Description  string    `json:"description"`
 	Links        Links     `json:"links"`
 	NextRelease  string    `json:"next_release"`
@@ -50,6 +50,10 @@ type Links struct {
 	LatestVersion Link `json:"latest_version"`
 	Versions      Link `json:"versions"`
 	Self          Link `json:"self"`
+	CodeList      Link `json:"code_list"`
+	Options       Link `json:"options"`
+	Version       Link `json:"version"`
+	Code          Link `json:"code"`
 }
 
 // Link represents a single link within a dataset model
@@ -63,4 +67,28 @@ type Contact struct {
 	Name      string `json:"name"`
 	Telephone string `json:"telephone"`
 	Email     string `json:"email"`
+}
+
+// Dimensions represent a list of dimensions from the dataset api
+type Dimensions struct {
+	Items []Dimension `json:"items"`
+}
+
+// Dimension represents a response model for a dimension endpoint
+type Dimension struct {
+	ID    string `json:"dimension_id"`
+	Links Links  `json:"links"`
+}
+
+// Options represents a list of options from the dataset api
+type Options struct {
+	Items []Option `json:"items"`
+}
+
+// Option represents a response model for an option
+type Option struct {
+	DimensionID string `json:"dimension_id"`
+	Label       string `json:"label"`
+	Links       Links  `json:"links"`
+	Option      string `json:"option"`
 }

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
@@ -156,3 +156,49 @@ func (c *Client) GetVersion(id, edition, version string) (m Version, err error) 
 	err = json.Unmarshal(b, &m)
 	return
 }
+
+// GetDimensions will return a versions dimensions
+func (c *Client) GetDimensions(id, edition, version string) (m Dimensions, err error) {
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions", c.url, id, edition, version)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidDatasetAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &m)
+	return
+}
+
+// GetOptions will return the options for a dimension
+func (c *Client) GetOptions(id, edition, version, dimension string) (m Options, err error) {
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options", c.url, id, edition, version, dimension)
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidDatasetAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &m)
+	return
+}

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
@@ -14,15 +14,27 @@ type DimensionOption struct {
 
 // Model represents a model returned from the filter api
 type Model struct {
-	FilterID        string              `json:"filter_job_id"`
-	DatasetFilterID string              `json:"dataset_filter_id"`
-	Dataset         string              `json:"dataset"`
-	Edition         string              `json:"edition"`
-	Version         string              `json:"version"`
-	State           string              `json:"state"`
-	Dimensions      []ModelDimension    `json:"dimensions,omitempty"`
-	Downloads       map[string]Download `json:"downloads,omitempty"`
-	Events          map[string][]Event  `json:"events,omitempty"`
+	FilterID   string              `json:"filter_job_id"`
+	InstanceID string              `json:"instance_id"`
+	Links      Links               `json:"links"`
+	Dataset    string              `json:"dataset"`
+	Edition    string              `json:"edition"`
+	Version    string              `json:"version"`
+	State      string              `json:"state"`
+	Dimensions []ModelDimension    `json:"dimensions,omitempty"`
+	Downloads  map[string]Download `json:"downloads,omitempty"`
+	Events     map[string][]Event  `json:"events,omitempty"`
+}
+
+// Links represents a links object on the filter api response
+type Links struct {
+	Version Link `json:"version,omitempty"`
+}
+
+// Link represents a single link within a links object
+type Link struct {
+	ID   string `json:"id"`
+	HRef string `json:"href"`
 }
 
 // ModelDimension represents a dimension to be filtered upon

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
@@ -136,14 +136,14 @@ func (c *Client) GetDimensionOptions(filterID, name string) (opts []DimensionOpt
 
 // CreateJob creates a filter job and returns the associated filterJobID
 func (c *Client) CreateJob(datasetFilterID string) (string, error) {
-	fj := Model{DatasetFilterID: datasetFilterID, State: "created"}
+	fj := Model{InstanceID: datasetFilterID, State: "created"}
 
 	b, err := json.Marshal(fj)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := http.Post(c.url+"/filters", "application/json", bytes.NewBuffer(b))
+	resp, err := c.cli.Post(c.url+"/filters", "application/json", bytes.NewBuffer(b))
 	if err != nil {
 		return "", err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -69,16 +69,16 @@
 			"revisionTime": "2017-08-25T14:03:29Z"
 		},
 		{
-			"checksumSHA1": "IOf3b7fsX/HxL4OZtRLfeS/ouXI=",
+			"checksumSHA1": "wS0lnWSzNIT8KANTZgWT5gC4VgM=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
-			"revisionTime": "2017-09-07T12:17:38Z"
+			"revision": "76be3910cc79807d234ffce7fc0abc8909e54ab6",
+			"revisionTime": "2017-09-18T10:29:06Z"
 		},
 		{
-			"checksumSHA1": "6UpikgNe2YnsPU0J+SByMPEOsUQ=",
+			"checksumSHA1": "1y/LdVtDtWMf4g/L9SJfMSv6ONc=",
 			"path": "github.com/ONSdigital/go-ns/clients/filter",
-			"revision": "8d823faf3c9b2cd9dd887b6e941ac7818688053a",
-			"revisionTime": "2017-09-14T10:16:45Z"
+			"revision": "76be3910cc79807d234ffce7fc0abc8909e54ab6",
+			"revisionTime": "2017-09-18T10:29:06Z"
 		},
 		{
 			"checksumSHA1": "z9+CybPTi4In8GFS6tsE9b/JYjY=",


### PR DESCRIPTION
- Get dimensions from dataset api
- Unstub filter api

To test, you will need to have run the import process

- Ensure the instance id from your import process matches the instance id in your version resource for mongodb

Run these services on the given branches and the rest on cmd-develop

- dp-frontend-dataset-controller `feature/dimensions`
- dp-frontend-filter-dataset-controller `feature/dimensions`
- dp-frontend-renderer `feature/dimensions`
- dp-filter-api `feature/instance-incl-version`
- dp-dataset-api `feature/instance-incl-version`
- dp-dataset-exporter `feature/instance-incl-version`

Verify you can navigate through the filter journey and create a filtered csv at the end 