### PR TITLE
Add taxonomy domain to pages from environment variable

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -42,8 +42,6 @@ func CreateFilterOverview(dimensions []filter.ModelDimension, filter filter.Mode
 	p.Metadata.Title = "Filter Options"
 	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 
-	log.Debug("dom", log.Data{"domain": p.TaxonomyDomain})
-
 	disableButton := true
 
 	for _, d := range dimensions {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -39,6 +40,9 @@ func CreateFilterOverview(dimensions []filter.ModelDimension, filter filter.Mode
 
 	p.FilterID = filterID
 	p.Metadata.Title = "Filter Options"
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+
+	log.Debug("dom", log.Data{"domain": p.TaxonomyDomain})
 
 	disableButton := true
 
@@ -130,6 +134,7 @@ func CreateListSelectorPage(name string, selectedValues []filter.DimensionOption
 	p.FilterID = filter.FilterID
 	p.Data.Title = dimensionTitleTranslator[name]
 	p.Metadata.Title = dimensionTitleTranslator[name]
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {
@@ -276,6 +281,7 @@ func CreateRangeSelectorPage(name string, selectedValues []filter.DimensionOptio
 	log.Debug("mapping api response models to range selector page model", log.Data{"filterID": filter.FilterID, "datasetID": datasetID, "dimension": name})
 
 	p.SearchDisabled = true
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {
@@ -408,6 +414,7 @@ func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, 
 	log.Debug("mapping api responses to preview page model", log.Data{"filterID": filterID, "datasetID": datasetID})
 
 	p.SearchDisabled = true
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {
@@ -491,6 +498,7 @@ func CreateHierarchyPage(h hierarchyClient.Model, parents []hierarchyClient.Pare
 	}
 
 	p.SearchDisabled = true
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 
 	versionURL, err := url.Parse(f.Links.Version.HRef)
 	if err != nil {

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -5,6 +5,7 @@ type Page struct {
 	Type                             string         `json:"type"`
 	URI                              string         `json:"uri"`
 	Taxonomy                         []TaxonomyNode `json:"taxonomy"`
+	TaxonomyDomain                   string         `json:"taxonomy_domain"`
 	Breadcrumb                       []TaxonomyNode `json:"breadcrumb"`
 	ServiceMessage                   string         `json:"service_message"`
 	Metadata                         Metadata       `json:"metadata"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "HGcaKsLnyiPHC1fYKvGTIH00Z4c=",
+			"checksumSHA1": "VQMD7iWcIW9cv7W1+ouzUon3OAo=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "fd87760f288b942010fdb9db9ae9ffe91212ad36",
-			"revisionTime": "2017-07-18T12:33:43Z"
+			"revision": "ee9872e6e3ac1d06162869349052bbcfc3fcaa13",
+			"revisionTime": "2017-10-05T07:32:47Z"
 		},
 		{
 			"checksumSHA1": "WFzDhLFdAQv2xOSf1cfT5ao2Aqs=",


### PR DESCRIPTION
- Use env var to create a taxonomy domain
- Update stubbed downloads to use response from dataset api

# How to test

Set the environment variable `TAXONOMY_DOMAIN=https://www.ons.gov.uk`

Verify that the taxonomy is fully populated through the cmd journey and redirects you to the live site

Verify when the environment variable is not set then the taxonomy takes you to links on your local environment