### PR TITLE
Remove range selector and set flat list default

### DIFF
--- a/handlers/time.go
+++ b/handlers/time.go
@@ -200,6 +200,11 @@ func (f *Filter) Time(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if len(allValues.Items) <= 20 {
+		f.DimensionSelector(w, req)
+		return
+	}
+
 	selValues, err := f.FilterClient.GetDimensionOptions(filterID, "time")
 	if err != nil {
 		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -161,7 +161,7 @@ func CreateListSelectorPage(name string, selectedValues []filter.DimensionOption
 		URI:   fmt.Sprintf("/filters/%s/dimensions", filter.FilterID),
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
-		Title: dimensionTitleTranslator[name],
+		Title: pageTitle,
 	})
 
 	p.Data.AddFromRange = listSelector.Link{

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -120,7 +120,7 @@ func TestUnitMapper(t *testing.T) {
 		So(p.Data.Cancel.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(p.Data.AddAllInRange.Label, ShouldEqual, "All times")
 		So(p.Data.RangeData.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/list")
-		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all?selectorType=list")
+		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all")
 		So(p.Data.RangeData.Values, ShouldHaveLength, 3)
 		So(p.Data.RangeData.Values[0].Label, ShouldEqual, "Feb-10")
 		So(p.Data.RangeData.Values[0].IsSelected, ShouldBeFalse)
@@ -129,59 +129,6 @@ func TestUnitMapper(t *testing.T) {
 		So(p.Data.RangeData.Values[2].Label, ShouldEqual, "Apr-10")
 		So(p.Data.RangeData.Values[2].IsSelected, ShouldBeFalse)
 		So(p.Data.FiltersAmount, ShouldEqual, 2)
-		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
-		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
-		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")
-		So(p.Metadata.Footer.DatasetID, ShouldEqual, "12345")
-	})
-
-	Convey("test CreateRangeSelectorPage successfully maps to a rangeSelector page model", t, func() {
-
-		allValues := dataset.Options{
-			Items: []dataset.Option{
-				{
-					Label:  "Feb-10",
-					Option: "abcdefg",
-				},
-				{
-					Label:  "Mar-10",
-					Option: "38jd83ik",
-				},
-				{
-					Label:  "Apr-10",
-					Option: "13984094",
-				},
-			},
-		}
-		dataset := getTestDataset()
-		selectedValues := []filter.DimensionOption{
-			{
-				Option: "38jd83ik",
-			},
-			{
-				Option: "bcdefg",
-			},
-		}
-
-		filter := getTestFilter()
-
-		p := CreateRangeSelectorPage("time", selectedValues, allValues, filter, dataset, "12345", "11-11-1992")
-		So(p.Data.Title, ShouldEqual, "Time")
-		So(p.SearchDisabled, ShouldBeTrue)
-		So(p.FilterID, ShouldEqual, filter.FilterID)
-
-		So(p.Breadcrumb, ShouldHaveLength, 3)
-		So(p.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
-		So(p.Breadcrumb[1].Title, ShouldEqual, "Filter options")
-		So(p.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
-		So(p.Breadcrumb[2].Title, ShouldEqual, "Time")
-		So(p.Data.AddFromList.Label, ShouldEqual, "Add time range")
-		So(p.Data.AddFromList.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time?selectorType=list")
-		So(p.Data.SaveAndReturn.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
-		So(p.Data.Cancel.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
-		So(p.Data.AddAllInRange.Label, ShouldEqual, "All times")
-		So(p.Data.RangeData.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/range")
-		So(p.Data.RemoveAll.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time/remove-all")
 		So(p.Metadata.Footer.Enabled, ShouldBeTrue)
 		So(p.Metadata.Footer.Contact, ShouldEqual, dataset.Contacts[0].Name)
 		So(p.Metadata.Footer.ReleaseDate, ShouldEqual, "11-11-1992")

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -55,7 +55,6 @@ func Init(r *mux.Router) (*renderer.Renderer, *filter.Client, *dataset.Client, *
 	r.Path("/filters/{filterID}/dimensions/{name}/update").HandlerFunc(filter.HierarchyUpdate)
 	r.Path("/filters/{filterID}/dimensions/{name}/{code}/update").HandlerFunc(filter.HierarchyUpdate)
 	r.Path("/filters/{filterID}/dimensions/{name}/remove/{option}").HandlerFunc(filter.DimensionRemoveOne)
-	r.Path("/filters/{filterID}/dimensions/{name}/range").Methods("POST").HandlerFunc(filter.AddRange)
 	r.Path("/filters/{filterID}/dimensions/{name}/list").Methods("POST").HandlerFunc(filter.AddList)
 	r.Path("/filters/{filterID}/dimensions/{name}{uri:.*}/remove-all").HandlerFunc(filter.DimensionRemoveAll)
 	r.Path("/filters/{filterID}/dimensions/{name}/options.json").HandlerFunc(filter.GetSelectedDimensionOptionsJSON)

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/time/time.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/time/time.go
@@ -22,6 +22,7 @@ type Data struct {
 	SelectedStartYear  string   `json:"selected_start_year"`
 	SelectedEndMonth   string   `json:"selected_end_month"`
 	SelectedEndYear    string   `json:"selected_end_year"`
+	Type               string   `json:"type"`
 }
 
 // Link represents a link

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-09-08T08:49:08Z"
 		},
 		{
-			"checksumSHA1": "bUMCWuOI3j72aKOLOZIi0NlF9oo=",
+			"checksumSHA1": "UcgCMRZLH31hF9KcFhrKQXx/tFA=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/time",
-			"revision": "30fcf42e91e161487a12ae2c26611001b36c5ad2",
-			"revisionTime": "2017-10-26T09:20:50Z"
+			"revision": "c4e2fa5f4b28c2546abe87712a698cbc2033548f",
+			"revisionTime": "2017-11-14T11:29:23Z"
 		},
 		{
 			"checksumSHA1": "zgQXB6EtoNdvUCvMjxA6U9cfDDI=",


### PR DESCRIPTION
### What

- A dimension will default to a flat list if it has less than 20 options
- The range selector no longer exists
- Text updates to the time selector
- If a dimension name does not appear in the dimension name map, then it will
default to the uppercase first letter version of the original name

### How to review

It will be difficult to test the features on this for the current CPI dataset, due to neither dimension being a flat list. You will notice the text has changed on the time dimension on the labels to reflect UX changes.

### Who can review

Anyone