### PR TITLE
Toggle feedback form across filter journey

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -46,6 +46,7 @@ func CreateFilterOverview(dimensions []filter.ModelDimension, filter filter.Mode
 	p.FilterID = filterID
 	p.Metadata.Title = "Filter Options"
 	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+	p.ShowFeedbackForm = false
 
 	disableButton := true
 
@@ -136,6 +137,7 @@ func CreateListSelectorPage(name string, selectedValues []filter.DimensionOption
 	p.Data.Title = pageTitle
 	p.Metadata.Title = pageTitle
 	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+	p.ShowFeedbackForm = false
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {
@@ -230,6 +232,7 @@ func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, 
 
 	p.SearchDisabled = false
 	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+	p.ShowFeedbackForm = true
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -42,6 +42,7 @@ func TestUnitMapper(t *testing.T) {
 		So(fop.Breadcrumb, ShouldHaveLength, 2)
 		So(fop.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
 		So(fop.Breadcrumb[1].Title, ShouldEqual, "Filter options")
+		So(fop.ShowFeedbackForm, ShouldEqual, false)
 	})
 
 	Convey("test CreatePreviewPage correctly maps to previewPage frontend model", t, func() {
@@ -57,6 +58,7 @@ func TestUnitMapper(t *testing.T) {
 		So(pp.Breadcrumb[1].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(pp.Breadcrumb[2].Title, ShouldEqual, "Preview")
 		So(pp.Data.FilterID, ShouldEqual, filter.Links.FilterBlueprint.ID)
+		So(pp.ShowFeedbackForm, ShouldEqual, true)
 		if pp.Data.Downloads[0].Extension == "csv" {
 			So(pp.Data.Downloads[0].Extension, ShouldEqual, "csv")
 			So(pp.Data.Downloads[0].Size, ShouldEqual, "362783")
@@ -127,6 +129,7 @@ func TestUnitMapper(t *testing.T) {
 		So(p.Data.RangeData.Values[2].Label, ShouldEqual, "Apr-10")
 		So(p.Data.RangeData.Values[2].IsSelected, ShouldBeFalse)
 		So(p.Data.FiltersAmount, ShouldEqual, 2)
+		So(p.ShowFeedbackForm, ShouldEqual, false)
 	})
 }
 

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -14,4 +14,5 @@ type Page struct {
 	PatternLibraryAssetsPath         string         `json:"-"`
 	Language                         string         `json:"-"`
 	IncludeAssetsIntegrityAttributes bool           `json:"-"`
+	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,16 +3,16 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "vE8Q5SmiWEfLFQLZhGGn7IvDYdc=",
+			"checksumSHA1": "Z5R3TnOvj8vWunyy96766ngQD/s=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "fc7563805b8e92cc9f36da19410d4aab7586e3b2",
-			"revisionTime": "2017-12-07T11:08:14Z"
+			"revision": "ce2fc0d4ebd4ed25a1e308b486bbc21383ce3107",
+			"revisionTime": "2017-12-07T15:30:01Z"
 		},
 		{
 			"checksumSHA1": "WFzDhLFdAQv2xOSf1cfT5ao2Aqs=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview",
-			"revision": "bb3aa88cefc1b32f0c431d6773407983fc69e6bb",
-			"revisionTime": "2017-09-18T14:39:20Z"
+			"revision": "ce2fc0d4ebd4ed25a1e308b486bbc21383ce3107",
+			"revisionTime": "2017-12-07T15:30:01Z"
 		},
 		{
 			"checksumSHA1": "ohl+vTwFS7rzrSwF76vtG+Jk9NM=",


### PR DESCRIPTION
### What

Only show the feedback form on the preview and download page when on a filter journey.

### How to review

1) Check out the render and filter dataset controller to `feature/feedback-form-toggle`
2) Go to a filter job (new or old, doesn't matter)
3) The feedback bar at the bottom of the page should only show on the preview and download page

### Who can review

Anyone but me.
