### PR TITLE
Update routing to fix a hierarchy remove from basket issue

### DIFF
--- a/routes/routes.go
+++ b/routes/routes.go
@@ -57,6 +57,7 @@ func Init(r *mux.Router) (*renderer.Renderer, *filter.Client, *dataset.Client, *
 	r.Path("/filters/{filterID}/dimensions/{name}/add-all").HandlerFunc(filter.DimensionAddAll)
 	r.Path("/filters/{filterID}/dimensions/{name}/update").HandlerFunc(filter.HierarchyUpdate)
 	r.Path("/filters/{filterID}/dimensions/{name}/{code}/update").HandlerFunc(filter.HierarchyUpdate)
+	r.Path("/filters/{filterID}/dimensions/{name}/{parent}/remove/{option}").HandlerFunc(filter.DimensionRemoveOne)
 	r.Path("/filters/{filterID}/dimensions/{name}/remove/{option}").HandlerFunc(filter.DimensionRemoveOne)
 	r.Path("/filters/{filterID}/dimensions/{name}/list").Methods("POST").HandlerFunc(filter.AddList)
 	r.Path("/filters/{filterID}/dimensions/{name}{uri:.*}/remove-all").HandlerFunc(filter.DimensionRemoveAll)


### PR DESCRIPTION
### What

Fix hierarchy bug
Update filter options screen for mobile

### How to review

Hierarchy bug:
Navigate 2 levels down in a hierarchy
Add 6 items
Remove 2 from the basket
Click back to previous level
Verify only four in the basket

Mobile:
Verify that the filter options page works for mobile

### Who can review

Anyone