### PR TITLE
Updated mapper and routes for the preview page

### DIFF
--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -193,6 +193,27 @@ func (f *Filter) PreviewPage(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (f *Filter) GetFilterJob(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	filterOutputID := vars["filterOutputID"]
+
+	prev, err := f.FilterClient.GetOutput(filterOutputID)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	b, err := json.Marshal(prev)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(b)
+}
+
 func (f *Filter) getMetadataTextSize(datasetID, edition, version string, metadata dataset.Metadata, dimensions dataset.Dimensions) (int, error) {
 	var b bytes.Buffer
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -274,12 +274,12 @@ func CreateListSelectorPage(name string, selectedValues []filter.DimensionOption
 }
 
 // CreatePreviewPage maps data items from API responses to create a preview page
-func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, dst dataset.Model, filterID, datasetID, releaseDate string) previewPage.Page {
+func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, dst dataset.Model, filterOutputID, datasetID, releaseDate string) previewPage.Page {
 	var p previewPage.Page
 	p.Metadata.Title = "Preview and Download"
 	SetTaxonomyDomain(&p.Page)
 
-	log.Debug("mapping api responses to preview page model", log.Data{"filterID": filterID, "datasetID": datasetID})
+	log.Debug("mapping api responses to preview page model", log.Data{"filterOutputID": filterOutputID, "datasetID": datasetID})
 
 	p.SearchDisabled = false
 	p.ShowFeedbackForm = true
@@ -303,6 +303,7 @@ func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, 
 	})
 
 	p.Data.FilterID = filter.Links.FilterBlueprint.ID
+	p.Data.FilterOutputID = filterOutputID
 
 	p.DatasetTitle = dst.Title
 	p.Data.DatasetID = datasetID

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -40,6 +40,7 @@ func Init(r *mux.Router) (*renderer.Renderer, *filter.Client, *dataset.Client, *
 
 	r.Path("/healthcheck").HandlerFunc(healthcheck.Do)
 
+	r.Path("/filter-outputs/{filterOutputID}.json").Methods("GET").HandlerFunc(filter.GetFilterJob)
 	r.Path("/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(filter.PreviewPage)
 
 	r.Path("/filters/{filterID}/submit").Methods("POST").HandlerFunc(filter.Submit)

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
@@ -23,6 +23,7 @@ type PreviewPage struct {
 	Edition               string        `json:"edition"`
 	ReleaseDate           string        `json:"release_date"`
 	SingleValueDimensions []Dimension   `json:"single_value_dimensions"`
+	FilterOutputID        string        `json:"filter_output_id"`
 }
 
 // Download has the details for an individual downloadable files

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-12-08T12:08:51Z"
 		},
 		{
-			"checksumSHA1": "AOeUigZrxry1XMj7+yQQLpYL8lE=",
+			"checksumSHA1": "IhnfQrvr8K3cZKX+PEP275F+LRc=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
-			"revision": "cb4e58dfd37eb1aa358e2b0e096aa74e1d0f07dd",
-			"revisionTime": "2017-12-28T08:15:36Z"
+			"revision": "ab79e77b73d577ae80b4c188d4655b576b1e0e33",
+			"revisionTime": "2018-01-18T14:47:10Z"
 		},
 		{
 			"checksumSHA1": "SoY8FqCX3h81+IizLi5lWsFydmU=",


### PR DESCRIPTION
### What

Updated the mapper and routes to allow for js enhanced creation of download files.

### How to review

Pull the following branches:

- Renderer - feature/js-enhance-preview
- Filter-controller - feature/js-enhance-preview
- sixteens - feature/js-enhance-preview

- Ensure that the files are generated without the need for a page refresh.
- Disable JS and check that a refresh page button is displayed if the downloads are still building.
- Stop a required service i.e. dp-dataset-exporter-xlsx - Check that an error is displayed after a couple of minutes.

### Who can review

Anyone.