### PR TITLE
Add 'Unit of measurement' to CMD preview

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -304,6 +304,7 @@ func CreatePreviewPage(dimensions []filter.ModelDimension, filter filter.Model, 
 	p.SearchDisabled = false
 	p.ShowFeedbackForm = true
 	p.ReleaseDate = releaseDate
+	p.Data.UnitOfMeasurement = dst.UnitOfMeasure
 
 	versionURL, err := url.Parse(filter.Links.Version.HRef)
 	if err != nil {

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
@@ -22,6 +22,7 @@ type PreviewPage struct {
 	DatasetID             string        `json:"dataset_id"`
 	Edition               string        `json:"edition"`
 	ReleaseDate           string        `json:"release_date"`
+	UnitOfMeasurement     string        `json:"unit_of_measurement"`
 	SingleValueDimensions []Dimension   `json:"single_value_dimensions"`
 	FilterOutputID        string        `json:"filter_output_id"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-12-08T12:08:51Z"
 		},
 		{
-			"checksumSHA1": "IhnfQrvr8K3cZKX+PEP275F+LRc=",
+			"checksumSHA1": "J7AEuI9kCqpTEpWvhOEq4xo4toM=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
-			"revision": "ab79e77b73d577ae80b4c188d4655b576b1e0e33",
-			"revisionTime": "2018-01-18T14:47:10Z"
+			"revision": "f6aedb9b3db83ff9810c467bfe72277300a1f51b",
+			"revisionTime": "2018-02-19T11:44:16Z"
 		},
 		{
 			"checksumSHA1": "UcgCMRZLH31hF9KcFhrKQXx/tFA=",


### PR DESCRIPTION
### What

https://trello.com/c/sqMAzb7G/3083-add-unit-of-measurement-to-cmd-preview

added .Data.UnitOfMeasurement to template 
https://github.com/ONSdigital/dp-frontend-renderer/pull/210

p.Data.UnitOfMeasurement to mapper

json:"unit_of_measurement" in PreviewPage struct
https://github.com/ONSdigital/dp-frontend-models/pull/24

### How to review

https://beta.ons.gov.uk/filter-outputs/32112ac0-6f68-4efc-b03c-083aa5436534
and a filter-outputs page with no unit of measurement

### Who can review

jon or crispin
