### PR TITLE
Add roots children if geography hierarchy format not satisfied

### DIFF
--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -390,6 +390,10 @@ func (f *Filter) flattenGeographyTopLevel(instanceID string) (h hierarchy.Model,
 		}
 	}
 
+	if len(children) == 0 {
+		children = root.Children
+	}
+
 	h.Children = children
 	return h, err
 }


### PR DESCRIPTION
### What

when geography hierarchies didn't contain a root which had children in the predefined list, children was set to an empty list.

fix was to in this case overwrite the children with the original hierarchy API responses' children

### How to review

check lower level geography hierarchies display correctly ( CCG is a good test for this)

### Who can review

anyone