### PR TITLE
Add splitCodes check function to return error when code isnt recognized

### DIFF
--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -320,6 +320,7 @@ func sortedTime(opts dataset.Options) dataset.Options {
 		month, year, err := splitCode(o.Links.Code.ID)
 		if err != nil {
 			log.Debug("option format is not sortable, returning flat list", log.Data{"code": o.Links.Code.ID})
+			break
 		}
 
 		var monthOrder int
@@ -392,7 +393,7 @@ func splitCode(id string) (string, string, error) {
 		return "", "", errors.New("code does not match expected format")
 	}
 
-	month := code[1]
+	month := code[len(code)-2]
 	month = strings.ToLower(month)
 
 	year := code[len(code)-1]


### PR DESCRIPTION
### What

Add splitCodes check function to return error when code isnt recognized

Previously, the code was panicking as the index was not found when the code never contained the '-' delimiter

### How to review

check actually works across multiple time list formats (i have tested against cpih, mid year pop and labour market locally - cpih uses the range selector, mid year pop no longer throws an error and just returns years and labour market sorts the weird time format correctly)

### Who can review

anyone