### PR TITLE
Made the beta banner only appear on the following pages:

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -46,6 +46,7 @@ func SetTaxonomyDomain(p *model.Page) {
 func CreateFilterOverview(ctx context.Context, dimensions []filter.ModelDimension, datasetDims dataset.Items, filter filter.Model, dst dataset.Model, filterID, datasetID, releaseDate string) filterOverview.Page {
 	var p filterOverview.Page
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api response models into filter overview page model", log.Data{"filterID": filterID, "datasetID": datasetID})
 
@@ -165,7 +166,7 @@ func CreateFilterOverview(ctx context.Context, dimensions []filter.ModelDimensio
 func CreateListSelectorPage(ctx context.Context, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dst dataset.Model, dims dataset.Dimensions, datasetID, releaseDate string) listSelector.Page {
 	var p listSelector.Page
 	SetTaxonomyDomain(&p.Page)
-
+	p.BetaBannerEnabled = true
 	log.InfoCtx(ctx, "mapping api response models to list selector page model", log.Data{"filterID": filter.FilterID, "datasetID": datasetID, "dimension": name})
 
 	pageTitle := strings.Title(name)
@@ -308,6 +309,7 @@ func CreatePreviewPage(ctx context.Context, dimensions []filter.ModelDimension, 
 	var p previewPage.Page
 	p.Metadata.Title = "Preview and Download"
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api responses to preview page model", log.Data{"filterOutputID": filterOutputID, "datasetID": datasetID})
 
@@ -392,6 +394,7 @@ func getIDNameLookup(vals dataset.Options) map[string]string {
 func CreateAgePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string) (age.Page, error) {
 	var p age.Page
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api responses to age page model", log.Data{"filterID": f.FilterID, "datasetID": datasetID})
 
@@ -525,6 +528,7 @@ func CreateAgePage(ctx context.Context, f filter.Model, d dataset.Model, v datas
 func CreateTimePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string) (timeModel.Page, error) {
 	var p timeModel.Page
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api responses to time page model", log.Data{"filterID": f.FilterID, "datasetID": datasetID})
 
@@ -696,6 +700,7 @@ func CreateTimePage(ctx context.Context, f filter.Model, d dataset.Model, v data
 func CreateHierarchySearchPage(ctx context.Context, items []search.Item, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, dims []dataset.Dimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query string) hierarchy.Page {
 	var p hierarchy.Page
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api response models to hierarchy search page", log.Data{"filterID": f.FilterID, "datasetID": datasetID, "name": name})
 
@@ -799,6 +804,7 @@ func CreateHierarchySearchPage(ctx context.Context, items []search.Item, dst dat
 func CreateHierarchyPage(ctx context.Context, h hierarchyClient.Model, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, allVals dataset.Options, dims dataset.Dimensions, name, curPath, datasetID, releaseDate string) hierarchy.Page {
 	var p hierarchy.Page
 	SetTaxonomyDomain(&p.Page)
+	p.BetaBannerEnabled = true
 
 	log.InfoCtx(ctx, "mapping api response models to hierarchy page", log.Data{"filterID": f.FilterID, "datasetID": datasetID, "label": h.Label})
 

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/metadata.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/metadata.go
@@ -4,5 +4,6 @@ package model
 type Metadata struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
+	ServiceName string   `json:"serviceName"`
 	Keywords    []string `json:"keywords"`
 }

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -19,4 +19,5 @@ type Page struct {
 	IncludeAssetsIntegrityAttributes bool           `json:"-"`
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
+	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2017-12-20T15:25:36Z"
 		},
 		{
-			"checksumSHA1": "ubWg5ErV6hnoLoGFHiTxIiVmESo=",
+			"checksumSHA1": "hEDY1K4lAova2Ej92ia5HeyQMME=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "ab79e77b73d577ae80b4c188d4655b576b1e0e33",
-			"revisionTime": "2018-01-18T14:47:10Z"
+			"revision": "45cb171b8e0b9ea6c197afc7c43e0ac87816572c",
+			"revisionTime": "2019-06-19T09:55:20Z"
 		},
 		{
 			"checksumSHA1": "4HqfcBn97KejGsi17+7HiYKDosw=",


### PR DESCRIPTION
### What

The beta banner now selectively displayed
It should appear on the following types of pages 

- version
- versions list
- edition
- filter journey pages:
  -  Age
  -  Time
  -  Hierarchy
  -  Hierarchy Search
  -  Preview
  -  ListSelector
  -  Filter Overview

### How to review

Checkout the following PRs:
dp-frontend-models: https://github.com/ONSdigital/dp-frontend-models/pull/40
dp-frontend-dataset-controller: https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/118
dp-frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/296

Run the CMD stack
Checkout different types of pages, ensure that the Beta banner only appears on CMD pages

### Who can review

Anyone except me
