### PR TITLE
Hotfix/collection id helper

### DIFF
--- a/vendor/github.com/ONSdigital/go-ns/handlers/collectionID/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/collectionID/handler.go
@@ -2,8 +2,8 @@ package collectionID
 
 import (
 	"context"
-	"net/http"
 	"errors"
+	"net/http"
 
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/log"
@@ -31,7 +31,7 @@ func CheckCookie(h http.Handler) http.Handler {
 
 		collectionIDCookie, err := req.Cookie(common.CollectionIDCookieKey)
 		if err == nil {
-			collectionID := collectionIDCookie.String()
+			collectionID := collectionIDCookie.Value
 			req = req.WithContext(context.WithValue(req.Context(), common.CollectionIDHeaderKey, collectionID))
 		} else {
 			if err != http.ErrNoCookie {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,10 +141,10 @@
 			"revisionTime": "2019-09-16T10:14:16Z"
 		},
 		{
-			"checksumSHA1": "vTOAgsj69LFRQVsg/Of0O8B/eaY=",
+			"checksumSHA1": "P5NQRDEiQJNSdTZqgcfR/o5T43Q=",
 			"path": "github.com/ONSdigital/go-ns/handlers/collectionID",
-			"revision": "caee21dda39f1143056a5ec0b3031036e14c7c42",
-			"revisionTime": "2019-05-20T09:08:57Z"
+			"revision": "6df4535416a74cab3a02f6aeb633e237334a1023",
+			"revisionTime": "2019-10-18T13:02:19Z"
 		},
 		{
 			"checksumSHA1": "ei+/RCSa0XO9v9rQxAh0uqyJ/28=",


### PR DESCRIPTION
### What

**Hotfix**: Updated vendor dependency `"github.com/ONSdigital/go-ns/handlers/collectionID"` to ensure collection ID header is set correctly.

Old version uses `cookie.String()` which returns `name=value` instead of just `value`
