### PR TITLE
Expose CurrentVersionURL to previewPage template

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -315,6 +315,8 @@ func CreatePreviewPage(ctx context.Context, dimensions []filter.ModelDimension, 
 		log.ErrorCtx(ctx, err, nil)
 	}
 
+	p.Data.CurrentVersionURL = versionURL.Path
+
 	p.IsInFilterBreadcrumb = true
 
 	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage/preview-page.go
@@ -19,6 +19,7 @@ type PreviewPage struct {
 	Dimensions            []Dimension   `json:"dimensions"`
 	IsLatestVersion       bool          `json:"is_latest_version"`
 	LatestVersion         LatestVersion `json:"latest_version"`
+	CurrentVersionURL     string        `json:"current_version_url"`
 	DatasetTitle          string        `json:"dataset_title"`
 	DatasetID             string        `json:"dataset_id"`
 	Edition               string        `json:"edition"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -87,10 +87,10 @@
 			"revisionTime": "2017-12-08T12:08:51Z"
 		},
 		{
-			"checksumSHA1": "VGEsERupXB8lMJzGiT3At5fj7yU=",
+			"checksumSHA1": "EC4y2S+JKkXVgZzvUZeY5QbpmQY=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/previewPage",
-			"revision": "3cd0596fd970153e89fcdfd325f033cf6bb5d144",
-			"revisionTime": "2019-11-04T09:47:41Z"
+			"revision": "88c08cb006929f6fdd2ccf15f62625b9033e41db",
+			"revisionTime": "2019-11-07T13:23:29Z"
 		},
 		{
 			"checksumSHA1": "UcgCMRZLH31hF9KcFhrKQXx/tFA=",


### PR DESCRIPTION
### What

Exposed the `CurrentVersionURL` to the `previewPage` template so that the 'dataset page' link can be updated to return the user to the dataset for the current version rather than the most recent version.

### How to review

- Pull changes in the feature/current-version-url for the `dp-frontend-models` and `dp-frontend-renderer` repositories as well.
- Navigate to a dataset on the website that has more than one version - select an older version.
-Click 'Filter and download' and then go through steps to apply filters
- Find text, 'Refer to the dataset page for more information...'
- Check that 'dataset page' hyperlink returns to the dataset version you were viewing.

### Who can review

Anyone
