### PR TITLE
Feature/add loop11 flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	SearchAPIURL         string `envconfig:"SEARCH_API_URL"`
 	DownloadServiceURL   string `envconfig:"DOWNLOAD_SERVICE_URL"`
 	EnableDatasetPreview bool   `envconfig:"ENABLE_DATASET_PREVIEW"`
+	EnableLoop11         bool   `envconfig:"ENABLE_LOOP11"`
 }
 
 var cfg *Config
@@ -38,6 +39,7 @@ func Get() (*Config, error) {
 		SearchAPIURL:         "http://localhost:23100",
 		DownloadServiceURL:   "http://localhost:23600",
 		EnableDatasetPreview: false,
+		EnableLoop11:         false,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -3,13 +3,14 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"net/http"
 	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/mapper"
@@ -62,7 +63,7 @@ func (f *Filter) UpdateAge(w http.ResponseWriter, req *http.Request) {
 	log.InfoCtx(ctx, "age-selection", log.Data{dimensionName: req.Form.Get("age-selection")})
 	switch req.Form.Get("age-selection") {
 	case "all":
-		if err := f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID,dimensionName, req.Form.Get("all-ages-option")); err != nil {
+		if err := f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID, dimensionName, req.Form.Get("all-ages-option")); err != nil {
 			log.ErrorCtx(ctx, err, log.Data{"age_case": "all"})
 		}
 	case "range":
@@ -239,7 +240,7 @@ func (f *Filter) Age(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	allValues, err := f.DatasetClient.GetOptions(ctx,  userAccessToken, "", collectionID, datasetID, edition, version, dimensionName)
+	allValues, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName)
 	if err != nil {
 		log.InfoCtx(ctx, "failed to get options from dataset client",
 			log.Data{"error": err, "dimension": dimensionName, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -267,7 +268,7 @@ func (f *Filter) Age(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p, err := mapper.CreateAgePage(ctx, fj, dataset, ver, allValues, selValues, dims, datasetID)
+	p, err := mapper.CreateAgePage(ctx, fj, dataset, ver, allValues, selValues, dims, datasetID, f.EnableLoop11)
 	if err != nil {
 		log.InfoCtx(ctx, "failed to map data to page", log.Data{"error": err, "filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})
 		setStatusCode(req, w, err)

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -427,7 +427,7 @@ func splitCode(id string) (string, string, error) {
 // ListSelector controls the render of the age selector list template
 // Contains stubbed data for now - page to be populated by the API
 func (f *Filter) listSelector(w http.ResponseWriter, req *http.Request, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dataset dataset.Model, dims dataset.Dimensions, datasetID, releaseDate string) {
-	p := mapper.CreateListSelectorPage(req.Context(), name, selectedValues, allValues, filter, dataset, dims, datasetID, releaseDate)
+	p := mapper.CreateListSelectorPage(req.Context(), name, selectedValues, allValues, filter, dataset, dims, datasetID, releaseDate, f.EnableLoop11)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -71,7 +71,7 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 	dimensionIDNameLookup := make(map[string]map[string]string)
 	for _, dim := range datasetDimensions.Items {
 		idNameLookup := make(map[string]string)
-		options, err := f.DatasetClient.GetOptions(req.Context(),  userAccessToken, "", collectionID, datasetID, edition, version, dim.Name)
+		options, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, dim.Name)
 		if err != nil {
 			log.InfoCtx(ctx, "failed to get options from dataset client",
 				log.Data{"error": err, "dimension": dim.Name, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -128,7 +128,7 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateFilterOverview(req.Context(), dimensions, datasetDimensions.Items, fj, dataset, filterID, datasetID, ver.ReleaseDate)
+	p := mapper.CreateFilterOverview(req.Context(), dimensions, datasetDimensions.Items, fj, dataset, filterID, datasetID, ver.ReleaseDate, f.EnableLoop11)
 
 	if latestURL.Path == versionURL.Path {
 		p.Data.IsLatestVersion = true

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -43,7 +43,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, "", false)
+			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions").HandlerFunc(f.FilterOverview)
 
 			router.ServeHTTP(w, req)
@@ -64,7 +64,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, "", false)
+			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/clear-all").HandlerFunc(f.FilterOverviewClearAll)
 
 			router.ServeHTTP(w, req)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,10 +19,11 @@ type Filter struct {
 	val                  Validator
 	downloadServiceURL   string
 	EnableDatasetPreview bool
+	EnableLoop11         bool
 }
 
 // NewFilter creates a new instance of Filter
-func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient, sc SearchClient, val Validator, downloadServiceURL string, enableDatasetPreview bool) *Filter {
+func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient, sc SearchClient, val Validator, downloadServiceURL string, enableDatasetPreview bool, enableLoop11 bool) *Filter {
 	return &Filter{
 		Renderer:             r,
 		FilterClient:         fc,
@@ -32,6 +33,7 @@ func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient
 		val:                  val,
 		downloadServiceURL:   downloadServiceURL,
 		EnableDatasetPreview: enableDatasetPreview,
+		EnableLoop11:         enableLoop11,
 	}
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -23,7 +23,7 @@ type Filter struct {
 }
 
 // NewFilter creates a new instance of Filter
-func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient, sc SearchClient, val Validator, downloadServiceURL string, enableDatasetPreview bool, enableLoop11 bool) *Filter {
+func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient, sc SearchClient, val Validator, downloadServiceURL string, enableDatasetPreview, enableLoop11 bool) *Filter {
 	return &Filter{
 		Renderer:             r,
 		FilterClient:         fc,

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/filter"
 	"github.com/ONSdigital/dp-api-clients-go/headers"
+	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/mapper"
-	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/mux"
 )
@@ -146,7 +146,6 @@ func (f *Filter) addAllHierarchyLevel(w http.ResponseWriter, req *http.Request, 
 			log.Error(err, nil)
 		}
 	}
-
 
 	var h hierarchy.Model
 	if len(code) > 0 {
@@ -282,7 +281,7 @@ func (f *Filter) Hierarchy(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	allVals, err := f.DatasetClient.GetOptions(req.Context(),  userAccessToken, "", collectionID, datasetID, edition, version, name)
+	allVals, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, name)
 	if err != nil {
 		log.InfoCtx(ctx, "failed to get options from dataset client",
 			log.Data{"error": err, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -298,7 +297,7 @@ func (f *Filter) Hierarchy(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchyPage(req.Context(), h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate)
+	p := mapper.CreateHierarchyPage(req.Context(), h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.EnableLoop11)
 
 	b, err := json.Marshal(p)
 	if err != nil {
@@ -346,7 +345,7 @@ func (n flatNodes) addWithChildren(val hierarchy.Child, i int) {
 
 // Flatten the geography hierarchy - please note this will only work for this particular hierarchy,
 // need helper functions for other geog hierarchies too.
-func (f *Filter) flattenGeographyTopLevel(ctx context.Context,instanceID string) (h hierarchy.Model, err error) {
+func (f *Filter) flattenGeographyTopLevel(ctx context.Context, instanceID string) (h hierarchy.Model, err error) {
 	root, err := f.HierarchyClient.GetRoot(ctx, instanceID, "geography")
 	if err != nil {
 		return

--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -164,7 +164,7 @@ func (f *Filter) OutputPage(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreatePreviewPage(req.Context(), dimensions, fj, dataset, filterOutputID, datasetID, ver.ReleaseDate, f.EnableDatasetPreview)
+	p := mapper.CreatePreviewPage(req.Context(), dimensions, fj, dataset, filterOutputID, datasetID, ver.ReleaseDate, f.EnableDatasetPreview, f.EnableLoop11)
 
 	if latestURL.Path == versionURL.Path {
 		p.Data.IsLatestVersion = true

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -110,7 +110,7 @@ func (f *Filter) Search(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchySearchPage(req.Context(), searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"))
+	p := mapper.CreateHierarchySearchPage(req.Context(), searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.EnableLoop11)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -61,7 +61,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -84,7 +84,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -111,7 +111,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -140,7 +140,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -170,7 +170,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -201,7 +201,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -233,7 +233,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -267,7 +267,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -296,7 +296,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, "", false, false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -284,7 +284,7 @@ func (f *Filter) Time(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p, err := mapper.CreateTimePage(req.Context(), fj, dataset, ver, allValues, selValues, dims, datasetID)
+	p, err := mapper.CreateTimePage(req.Context(), fj, dataset, ver, allValues, selValues, dims, datasetID, f.EnableLoop11)
 	if err != nil {
 		log.InfoCtx(ctx, "failed to map data to page", log.Data{"error": err, "filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})
 		setStatusCode(req, w, err)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -37,9 +37,10 @@ var topLevelGeographies = map[string]bool{
 
 // CreateFilterOverview maps data items from API responses to form a filter overview
 // front end page model
-func CreateFilterOverview(ctx context.Context, dimensions []filter.ModelDimension, datasetDims dataset.Items, filter filter.Model, dst dataset.Model, filterID, datasetID, releaseDate string) filterOverview.Page {
+func CreateFilterOverview(ctx context.Context, dimensions []filter.ModelDimension, datasetDims dataset.Items, filter filter.Model, dst dataset.Model, filterID, datasetID, releaseDate string, enableLoop11 bool) filterOverview.Page {
 	var p filterOverview.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api response models into filter overview page model", log.Data{"filterID": filterID, "datasetID": datasetID})
 
@@ -156,9 +157,10 @@ func CreateFilterOverview(ctx context.Context, dimensions []filter.ModelDimensio
 
 // CreateListSelectorPage maps items from API responses to form the model for a
 // dimension list selector page
-func CreateListSelectorPage(ctx context.Context, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dst dataset.Model, dims dataset.Dimensions, datasetID, releaseDate string) listSelector.Page {
+func CreateListSelectorPage(ctx context.Context, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dst dataset.Model, dims dataset.Dimensions, datasetID, releaseDate string, enableLoop11 bool) listSelector.Page {
 	var p listSelector.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 	log.InfoCtx(ctx, "mapping api response models to list selector page model", log.Data{"filterID": filter.FilterID, "datasetID": datasetID, "dimension": name})
 
 	pageTitle := strings.Title(name)
@@ -385,9 +387,10 @@ func getIDNameLookup(vals dataset.Options) map[string]string {
 }
 
 // CreateAgePage creates an age selector page based on api responses
-func CreateAgePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string) (age.Page, error) {
+func CreateAgePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string, enableLoop11 bool) (age.Page, error) {
 	var p age.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api responses to age page model", log.Data{"filterID": f.FilterID, "datasetID": datasetID})
 
@@ -518,9 +521,10 @@ func CreateAgePage(ctx context.Context, f filter.Model, d dataset.Model, v datas
 }
 
 // CreateTimePage will create a time selector page based on api response models
-func CreateTimePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string) (timeModel.Page, error) {
+func CreateTimePage(ctx context.Context, f filter.Model, d dataset.Model, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.Dimensions, datasetID string, enableLoop11 bool) (timeModel.Page, error) {
 	var p timeModel.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api responses to time page model", log.Data{"filterID": f.FilterID, "datasetID": datasetID})
 
@@ -689,9 +693,10 @@ func CreateTimePage(ctx context.Context, f filter.Model, d dataset.Model, v data
 }
 
 // CreateHierarchySearchPage forms a search page based on various api response models
-func CreateHierarchySearchPage(ctx context.Context, items []search.Item, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, dims []dataset.Dimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query string) hierarchy.Page {
+func CreateHierarchySearchPage(ctx context.Context, items []search.Item, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, dims []dataset.Dimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query string, enableLoop11 bool) hierarchy.Page {
 	var p hierarchy.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api response models to hierarchy search page", log.Data{"filterID": f.FilterID, "datasetID": datasetID, "name": name})
 
@@ -792,9 +797,10 @@ func CreateHierarchySearchPage(ctx context.Context, items []search.Item, dst dat
 }
 
 // CreateHierarchyPage maps data items from API responses to form a hirearchy page
-func CreateHierarchyPage(ctx context.Context, h hierarchyClient.Model, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, allVals dataset.Options, dims dataset.Dimensions, name, curPath, datasetID, releaseDate string) hierarchy.Page {
+func CreateHierarchyPage(ctx context.Context, h hierarchyClient.Model, dst dataset.Model, f filter.Model, selVals []filter.DimensionOption, allVals dataset.Options, dims dataset.Dimensions, name, curPath, datasetID, releaseDate string, enableLoop11 bool) hierarchy.Page {
 	var p hierarchy.Page
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api response models to hierarchy page", log.Data{"filterID": f.FilterID, "datasetID": datasetID, "label": h.Label})
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -297,11 +297,12 @@ func CreateListSelectorPage(ctx context.Context, name string, selectedValues []f
 }
 
 // CreatePreviewPage maps data items from API responses to create a preview page
-func CreatePreviewPage(ctx context.Context, dimensions []filter.ModelDimension, filter filter.Model, dst dataset.Model, filterOutputID, datasetID, releaseDate string, enableDatasetPreivew bool) previewPage.Page {
+func CreatePreviewPage(ctx context.Context, dimensions []filter.ModelDimension, filter filter.Model, dst dataset.Model, filterOutputID, datasetID, releaseDate string, enableDatasetPreivew bool, enableLoop11 bool) previewPage.Page {
 	var p previewPage.Page
 	p.Metadata.Title = "Preview and Download"
 	p.BetaBannerEnabled = true
 	p.EnableDatasetPreview = enableDatasetPreivew
+	p.EnableLoop11 = enableLoop11
 
 	log.InfoCtx(ctx, "mapping api responses to preview page model", log.Data{"filterOutputID": filterOutputID, "datasetID": datasetID})
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -55,7 +55,7 @@ func TestUnitMapper(t *testing.T) {
 		filter := getTestFilter()
 		dataset := getTestDataset()
 
-		pp := CreatePreviewPage(ctx, dimensions, filter, dataset, filter.FilterID, "12345", "11-11-1992", false)
+		pp := CreatePreviewPage(ctx, dimensions, filter, dataset, filter.FilterID, "12345", "11-11-1992", false, false)
 		So(pp.SearchDisabled, ShouldBeFalse)
 		So(pp.Breadcrumb, ShouldHaveLength, 4)
 		So(pp.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
@@ -156,7 +156,7 @@ func TestUnitMapper(t *testing.T) {
 						Label: "2017",
 					},
 				},
-			}, filter.Model{}, dataset.Model{}, dataset.Dimensions{}, "1234", "today")
+			}, filter.Model{}, dataset.Model{}, dataset.Dimensions{}, "1234", "today", false)
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 
@@ -182,7 +182,7 @@ func TestUnitMapper(t *testing.T) {
 						Label: "Ireland",
 					},
 				},
-			}, filter.Model{}, dataset.Model{}, dataset.Dimensions{}, "1234", "today")
+			}, filter.Model{}, dataset.Model{}, dataset.Dimensions{}, "1234", "today", false)
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -18,7 +18,7 @@ func TestUnitMapper(t *testing.T) {
 		filter := getTestFilter()
 		dst := getTestDataset()
 
-		fop := CreateFilterOverview(ctx, dimensions, datasetDimension, filter, dst, filter.FilterID, "12345", "11-11-1992")
+		fop := CreateFilterOverview(ctx, dimensions, datasetDimension, filter, dst, filter.FilterID, "12345", "11-11-1992", false)
 		So(fop.FilterID, ShouldEqual, filter.FilterID)
 		So(fop.SearchDisabled, ShouldBeTrue)
 		So(fop.Data.Dimensions, ShouldHaveLength, 5)
@@ -111,7 +111,7 @@ func TestUnitMapper(t *testing.T) {
 
 			filter := getTestFilter()
 
-			p := CreateListSelectorPage(ctx, "time", selectedValues, allValues, filter, d, dataset.Dimensions{}, "12345", "11-11-1992")
+			p := CreateListSelectorPage(ctx, "time", selectedValues, allValues, filter, d, dataset.Dimensions{}, "12345", "11-11-1992", false)
 			So(p.Data.Title, ShouldEqual, "Time")
 			So(p.SearchDisabled, ShouldBeTrue)
 			So(p.FilterID, ShouldEqual, filter.FilterID)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -38,7 +38,7 @@ func Init(r *mux.Router, cfg *config.Config) {
 	hc := hierarchy.New(cfg.HierarchyAPIURL)
 	sc := search.New(cfg.SearchAPIURL)
 
-	filter := handlers.NewFilter(rend, fc, dc, hc, sc, v, cfg.DownloadServiceURL, cfg.EnableDatasetPreview)
+	filter := handlers.NewFilter(rend, fc, dc, hc, sc, v, cfg.DownloadServiceURL, cfg.EnableDatasetPreview, cfg.EnableLoop11)
 
 	r.StrictSlash(true).Path("/healthcheck").HandlerFunc(healthcheck.Handler)
 

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -19,4 +19,5 @@ type Page struct {
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
 	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
+	EnableLoop11                     bool           `json:"enable_loop11"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -57,10 +57,10 @@
 			"revisionTime": "2017-12-20T15:25:36Z"
 		},
 		{
-			"checksumSHA1": "fJkBbYwFJnWgmIhmYaf5Pnt8CNk=",
+			"checksumSHA1": "5PuwTxKjJHFNFEaERgwzM7s6H9s=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "61a4fc32d261a3e49e950290423ec0b8050612a2",
-			"revisionTime": "2019-10-25T12:16:22Z"
+			"revision": "4b27e5097ae6ebf8ed429c0c2a2b4af330d913e6",
+			"revisionTime": "2019-12-03T15:13:28Z"
 		},
 		{
 			"checksumSHA1": "4HqfcBn97KejGsi17+7HiYKDosw=",


### PR DESCRIPTION
### What

Implemented a new flag, `ENABLE_LOOP11`, that will toggle the loading of the loop11 script for filter-dataset controller routes. This is set to false by default.

### How to review

1. Pull `feature/add-loop11-flag` branch for `dp-frontend-renderer`, `dp-frontend-models`, `dp-frontend-dataset-controller`, `dp-frontend-filter-dataset-controller` and `dp-geography-controller`.
2. Enable loop11 for each controller by including the flag, `ENABLE_LOOP11=true`
3. Check in network tab that loop11.js is present when visiting the specific pages for that controller.
4. Sense check that the loop11 script isn't loaded when the controller is run without the flag.

### Who can review

Anyone
