### PR TITLE
change add dimension values to single bulk call, needs to skip 'q' form parameter

### DIFF
--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -19,6 +19,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// these form vars are not regular input fields, but transmit meta form info
+var specialFormVars = map[string]bool{
+	"save-and-return": true,
+	":uri":            true,
+	"q":               true,
+}
+
 // HierarchyUpdate controls the updating of a hierarchy job
 func (f *Filter) HierarchyUpdate(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
@@ -118,7 +125,7 @@ func (f *Filter) HierarchyUpdate(w http.ResponseWriter, req *http.Request) {
 
 	options := make([]string, 0)
 	for k := range req.Form {
-		if k == "save-and-return" || k == ":uri" || k == "q" {
+		if _, foundSpecial := specialFormVars[k]; foundSpecial {
 			continue
 		}
 


### PR DESCRIPTION
### What

- use FilterClient.AddDimensionValues for adding multiple options for a dimension
- the above broke because the form value 'q' was secreted in the form to support its search aspect, so skip passing that param to the filter-api

### How to review

ensure adding bulk (e.g. 'add all') still works for hierarchies

### Who can review

CMD-aware froods
