### PR TITLE
Added profiler debug endpoint (configurable), with auth protection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ An HTTP service for the controlling of data relevant to the filtering of a parti
 | HIERARCHY_API_URL             | http://localhost:22600  | The URL of the hierarchy api
 | SEARCH_API_URL                | http://localhost:23100  | The URL of the search api
 | DOWNLOAD_SERVICE_URL          | http://localhost:23600  | The URL of the download service
+| ZEBEDEE_URL                   | http://localhost:8082   | The url of the zebedee service. Only required if profiler is enabled
 | DATASET_API_AUTH_TOKEN        | n/a                     | The token used to access the Dataset API
 | FILTER_API_AUTH_TOKEN         | n/a                     | The token used to access the Filter API
 | SEARCH_API_AUTH_TOKEN         | n/a                     | The token used to access the Search API
 | ENABLE_DATASET_PREVIEW        | false                   | Flag to add preview of dataset to output page
+| ENABLE_PROFILER               | false                   | Flag to enable go profiler
 | GRACEFUL_SHUTDOWN_TIMEOUT     | 5s                      | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL          | 30s                     | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT  | 90s                     | The time taken for the health changes from warning state to critical due to subsystem check failures 
@@ -38,6 +40,25 @@ Valid time units are
 "m" = minute
 "h" = hour
 ```
+
+### Profiling
+
+An optional `/debug` endpoint has been added, in order to profile this service via `pprof` go library.
+In order to use this endpoint, you will need to enable the flag and provide a valid ZebedeeURL, as it is auth-protected. Please, modify the following configuration variables to do so:
+```
+export ZEBEDEE_URL=your_zebedee_url
+export ENABLE_PROFILER=true
+```
+
+Then you can us the profiler as follows:
+
+1- Start service, load test or if on environment wait for a number of requests to be made.
+
+2- Send authenticated request and store response in a file (this can be best done in command line like so: `curl <host>:<port>/debug/pprof/heap > heap.out` - see pprof documentation on other endpoints
+
+3- View profile either using a web ui to navigate data (a) or using pprof on command line to navigate data (b) 
+  a) `go tool pprof -http=:8080 heap.out`
+  b) `go tool pprof heap.out`, -o flag to see various options
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ func Get() (cfg *Config, err error) {
 		SearchAPIURL:               "http://localhost:23100",
 		DownloadServiceURL:         "http://localhost:23600",
 		EnableDatasetPreview:       false,
-		EnableProfiler:             true,
+		EnableProfiler:             false,
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/config/config.go
+++ b/config/config.go
@@ -13,12 +13,14 @@ type Config struct {
 	FilterAPIURL               string        `envconfig:"FILTER_API_URL"`
 	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
 	HierarchyAPIURL            string        `envconfig:"HIERARCHY_API_URL"`
+	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"  json:"-"`
 	DatasetAPIAuthToken        string        `envconfig:"DATASET_API_AUTH_TOKEN" json:"-"`
 	FilterAPIAuthToken         string        `envconfig:"FILTER_API_AUTH_TOKEN"  json:"-"`
 	SearchAPIAuthToken         string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
 	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
 	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 	EnableDatasetPreview       bool          `envconfig:"ENABLE_DATASET_PREVIEW"`
+	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -36,12 +38,14 @@ func Get() (cfg *Config, err error) {
 		FilterAPIURL:               "http://localhost:22100",
 		DatasetAPIURL:              "http://localhost:22000",
 		HierarchyAPIURL:            "http://localhost:22600",
+		ZebedeeURL:                 "http://localhost:8082",
 		DatasetAPIAuthToken:        "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		FilterAPIAuthToken:         "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		SearchAPIAuthToken:         "SD0108EA-825D-411C-45J3-41EF7727F123",
 		SearchAPIURL:               "http://localhost:23100",
 		DownloadServiceURL:         "http://localhost:23600",
 		EnableDatasetPreview:       false,
+		EnableProfiler:             true,
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.10.0
 	github.com/ONSdigital/dp-frontend-models v1.4.2
 	github.com/ONSdigital/dp-healthcheck v1.0.3
+	github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/golang/mock v1.4.0
 	github.com/gorilla/mux v1.7.4
+	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=
 github.com/ONSdigital/dp-healthcheck v1.0.3/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8 h1:MWIHCr/ud5ur9elhfvKtSjMJInqf3iUY8F4J27qGQPA=
@@ -29,6 +30,7 @@ github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmA
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 h1:yswqe8UdKNWn4kjh1YTaAbvOSPeg95xhW7h4qeICL5E=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=


### PR DESCRIPTION
### What

- Created `/debug` endpoint for pprof, so that developers can easily profile this service in the future.
- Auth-protected the debug endpoints, with identity middleware
- Registered Zebedee checker if debug profiler is enabled

### How to review

- Make sure code changes make sense
- Unit tests should pass
- If you want, you can verify the `/health` and `/debug/pprof/heap` endpoints with debug enabled and disabled

### Who can review

Anyone