### PR TITLE
Add profiling token to validate user access to profiling endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ An HTTP service for the controlling of data relevant to the filtering of a parti
 | SEARCH_API_AUTH_TOKEN         | n/a                     | The token used to access the Search API
 | ENABLE_DATASET_PREVIEW        | false                   | Flag to add preview of dataset to output page
 | ENABLE_PROFILER               | false                   | Flag to enable go profiler
+| PPROF_TOKEN                   | ""                      | The profiling token to access service profiling
 | GRACEFUL_SHUTDOWN_TIMEOUT     | 5s                      | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL          | 30s                     | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT  | 90s                     | The time taken for the health changes from warning state to critical due to subsystem check failures 
@@ -44,17 +45,18 @@ Valid time units are
 ### Profiling
 
 An optional `/debug` endpoint has been added, in order to profile this service via `pprof` go library.
-In order to use this endpoint, you will need to enable the flag and provide a valid ZebedeeURL, as it is auth-protected. Please, modify the following configuration variables to do so:
+In order to use this endpoint, you will need to enable profiler flag and set a PPROF_TOKEN:
+
 ```
-export ZEBEDEE_URL=your_zebedee_url
 export ENABLE_PROFILER=true
+export PPROF_TOKEN={generated uuid}
 ```
 
 Then you can us the profiler as follows:
 
 1- Start service, load test or if on environment wait for a number of requests to be made.
 
-2- Send authenticated request and store response in a file (this can be best done in command line like so: `curl <host>:<port>/debug/pprof/heap > heap.out` - see pprof documentation on other endpoints
+2- Send authenticated request and store response in a file (this can be best done in command line like so: `curl <host>:<port>/debug/pprof/heap -H "Authorization: Bearer {generated uuid} > heap.out` - see pprof documentation on other endpoints
 
 3- View profile either using a web ui to navigate data (a) or using pprof on command line to navigate data (b) 
   a) `go tool pprof -http=:8080 heap.out`

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 	EnableDatasetPreview       bool          `envconfig:"ENABLE_DATASET_PREVIEW"`
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
+	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,7 @@ require (
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.10.0
 	github.com/ONSdigital/dp-frontend-models v1.4.2
 	github.com/ONSdigital/dp-healthcheck v1.0.3
-	github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8
-	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
+	github.com/ONSdigital/go-ns v0.0.0-20200511161740-afc39066ee62
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/golang/mock v1.4.0
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad/go.mod h1:uHT6LaUlRbJsJRrIlN31t+QLUB80tAbk6ZR9sfoHL8Y=
+github.com/ONSdigital/go-ns v0.0.0-20200511161740-afc39066ee62 h1:DyGIxcRIEEHGGb/FuvrWoYXvpbR0WDbnvEn9kBF4tvM=
+github.com/ONSdigital/go-ns v0.0.0-20200511161740-afc39066ee62/go.mod h1:uHT6LaUlRbJsJRrIlN31t+QLUB80tAbk6ZR9sfoHL8Y=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=


### PR DESCRIPTION
### What

Previously relied on communicating with authenticating service (API) but this may not exist, so use a configurable environment variable to validate an incoming request.

### How to review

Follow notes in README.md under Profiling:
- Should be able to only gain access to endpoint if the following criteria are met:
  - profiling is switched on in application
  - environment variable `PPROF_TOKEN` is set to a **non**-empty string
  - Request contains header `Authorization` and is equal to "`Bearer + {PPROF_TOKEN}`"

If the above are met, then you can use the following command to create a heap profile of app:

1) `curl <host>:<port>/debug/pprof/heap -H "Authorization: Bearer {generated uuid} > heap.out`
2) `go tool pprof -http=:8080 heap.out` <- without bombarding service this wont contain much information

### Who can review

Anyone
