### PR TITLE
Remove references to zebedee in controller

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ type Config struct {
 	FilterAPIURL               string        `envconfig:"FILTER_API_URL"`
 	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
 	HierarchyAPIURL            string        `envconfig:"HIERARCHY_API_URL"`
-	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"  json:"-"`
 	DatasetAPIAuthToken        string        `envconfig:"DATASET_API_AUTH_TOKEN" json:"-"`
 	FilterAPIAuthToken         string        `envconfig:"FILTER_API_AUTH_TOKEN"  json:"-"`
 	SearchAPIAuthToken         string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
@@ -39,7 +38,6 @@ func Get() (cfg *Config, err error) {
 		FilterAPIURL:               "http://localhost:22100",
 		DatasetAPIURL:              "http://localhost:22000",
 		HierarchyAPIURL:            "http://localhost:22600",
-		ZebedeeURL:                 "http://localhost:8082",
 		DatasetAPIAuthToken:        "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		FilterAPIAuthToken:         "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		SearchAPIAuthToken:         "SD0108EA-825D-411C-45J3-41EF7727F123",

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
-	"github.com/ONSdigital/dp-api-clients-go/health"
 	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-api-clients-go/search"
@@ -76,11 +75,6 @@ func run(ctx context.Context) error {
 		Dataset:   dataset.NewAPIClient(cfg.DatasetAPIURL),
 		Hierarchy: hierarchy.New(cfg.HierarchyAPIURL),
 		Search:    search.New(cfg.SearchAPIURL),
-	}
-
-	if cfg.EnableProfiler {
-		log.Event(ctx, "creating identity client, as profiler is enabled", log.INFO)
-		clients.ZebedeeHealth = health.NewClient("Zebedee", cfg.ZebedeeURL)
 	}
 
 	healthcheck := healthcheck.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
@@ -188,13 +182,6 @@ func registerCheckers(ctx context.Context, cfg *config.Config, clients routes.Cl
 	if err = clients.Healthcheck.AddCheck("search API", clients.Search.Checker); err != nil {
 		hasErrors = true
 		log.Event(ctx, "failed to add search API checker", log.ERROR, log.Error(err))
-	}
-
-	if cfg.EnableProfiler {
-		if err = clients.Healthcheck.AddCheck("Zebedee", clients.ZebedeeHealth.Checker); err != nil {
-			hasErrors = true
-			log.Event(ctx, "failed to add zebedee checker", log.ERROR, log.Error(err))
-		}
 	}
 
 	if hasErrors {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
-	"github.com/ONSdigital/dp-api-clients-go/health"
 	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-api-clients-go/search"
@@ -23,13 +22,12 @@ import (
 
 // Clients represents a list of clients
 type Clients struct {
-	Filter        *filter.Client
-	Dataset       *dataset.Client
-	Hierarchy     *hierarchy.Client
-	Healthcheck   *healthcheck.HealthCheck
-	Renderer      *renderer.Renderer
-	Search        *search.Client
-	ZebedeeHealth *health.Client
+	Filter      *filter.Client
+	Dataset     *dataset.Client
+	Hierarchy   *hierarchy.Client
+	Healthcheck *healthcheck.HealthCheck
+	Renderer    *renderer.Renderer
+	Search      *search.Client
 }
 
 // Init initialises routes for the service


### PR DESCRIPTION
### What

The zebedee client was created to authenticated requests hitting the profiling endpoint. This endpoint does not rely on a auth API and instead controls access via a PPROF_TOKEN. Hence removing zebedee from health checkers and zebedee client as well as config for zebedee url.

### How to review

Check changes make sense and unit tests still pass

### Who can review

Anyone
