### PR TITLE
Removed api router prefix (if present) when using HRef and URL values…

### DIFF
--- a/handlers/age.go
+++ b/handlers/age.go
@@ -221,9 +221,10 @@ func (f *Filter) Age(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -269,7 +270,7 @@ func (f *Filter) Age(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p, err := mapper.CreateAgePage(req, fj, dataset, ver, allValues, selValues, dims, datasetID)
+	p, err := mapper.CreateAgePage(req, fj, dataset, ver, allValues, selValues, dims, datasetID, f.APIRouterVersion)
 	if err != nil {
 		log.Event(ctx, "failed to map data to page", log.ERROR, log.Error(err),
 			log.Data{"filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -55,10 +55,11 @@ func (f *Filter) GetAllDimensionOptionsJSON(w http.ResponseWriter, req *http.Req
 		setStatusCode(req, w, err)
 		return
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
 
-	idNameMap, err := f.getIDNameMap(req.Context(), userAccessToken, versionURL.Path, name)
+	idNameMap, err := f.getIDNameMap(req.Context(), userAccessToken, versionPath, name)
 	if err != nil {
-		log.Event(ctx, "failed to get name map", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL, "name": name})
+		log.Event(ctx, "failed to get name map", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath, "name": name})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -158,9 +159,10 @@ func (f *Filter) GetSelectedDimensionOptionsJSON(w http.ResponseWriter, req *htt
 		setStatusCode(req, w, err)
 		return
 	}
-	idNameMap, err := f.getIDNameMap(req.Context(), userAccessToken, versionURL.Path, name)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	idNameMap, err := f.getIDNameMap(req.Context(), userAccessToken, versionPath, name)
 	if err != nil {
-		log.Event(ctx, "failed to get name map", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL, "name": name})
+		log.Event(ctx, "failed to get name map", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath, "name": name})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -242,10 +244,11 @@ func (f *Filter) DimensionSelector(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
 
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -427,7 +430,7 @@ func splitCode(id string) (string, string, error) {
 // Contains stubbed data for now - page to be populated by the API
 func (f *Filter) listSelector(w http.ResponseWriter, req *http.Request, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dataset dataset.DatasetDetails, dims dataset.VersionDimensions, datasetID, releaseDate string) {
 	ctx := req.Context()
-	p := mapper.CreateListSelectorPage(req, name, selectedValues, allValues, filter, dataset, dims, datasetID, releaseDate)
+	p := mapper.CreateListSelectorPage(req, name, selectedValues, allValues, filter, dataset, dims, datasetID, releaseDate, f.APIRouterVersion)
 
 	b, err := json.Marshal(p)
 	if err != nil {
@@ -482,9 +485,11 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL st
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -598,8 +603,9 @@ func (f *Filter) getDimensionValues(ctx context.Context, userAccessToken, filter
 	if err != nil {
 		return
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
 
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
 		return
 	}

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"unicode"
 
 	"github.com/ONSdigital/dp-api-clients-go/filter"
@@ -52,10 +53,11 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
 
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -125,14 +127,15 @@ func (f *Filter) FilterOverview(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	latestPath := strings.TrimPrefix(latestURL.Path, f.APIRouterVersion)
 
-	p := mapper.CreateFilterOverview(req, dimensions, datasetDimensions.Items, fj, dataset, filterID, datasetID, ver.ReleaseDate)
+	p := mapper.CreateFilterOverview(req, dimensions, datasetDimensions.Items, fj, dataset, filterID, datasetID, ver.ReleaseDate, f.APIRouterVersion)
 
-	if latestURL.Path == versionURL.Path {
+	if latestPath == versionPath {
 		p.Data.IsLatestVersion = true
 	}
 
-	p.Data.LatestVersion.DatasetLandingPageURL = latestURL.Path
+	p.Data.LatestVersion.DatasetLandingPageURL = latestPath
 	p.Data.LatestVersion.FilterJourneyWithLatestJourney = fmt.Sprintf("/filters/%s/use-latest-version", filterID)
 
 	b, err := json.Marshal(p)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -43,7 +43,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions").HandlerFunc(f.FilterOverview)
 
 			router.ServeHTTP(w, req)
@@ -64,7 +64,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/clear-all").HandlerFunc(f.FilterOverviewClearAll)
 
 			router.ServeHTTP(w, req)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -30,7 +30,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{filter.Dimension{Name: "Day"}, filter.Dimension{Name: "Goods and Services"}}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day").Return([]filter.DimensionOption{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services").Return([]filter.DimensionOption{}, nil)
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{Items: []dataset.VersionDimension{{Name: "geography"}}}, nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -21,11 +21,12 @@ type Filter struct {
 	val                  Validator
 	downloadServiceURL   string
 	EnableDatasetPreview bool
+	APIRouterVersion     string
 }
 
 // NewFilter creates a new instance of Filter
 func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient,
-	sc SearchClient, val Validator, searchAPIAuthToken, downloadServiceURL string, enableDatasetPreview bool) *Filter {
+	sc SearchClient, val Validator, searchAPIAuthToken, downloadServiceURL, apiRouterVersion string, enableDatasetPreview bool) *Filter {
 
 	return &Filter{
 		Renderer:             r,
@@ -37,6 +38,7 @@ func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient
 		downloadServiceURL:   downloadServiceURL,
 		EnableDatasetPreview: enableDatasetPreview,
 		SearchAPIAuthToken:   searchAPIAuthToken,
+		APIRouterVersion:     apiRouterVersion,
 	}
 }
 

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -312,7 +312,7 @@ func (f *Filter) Hierarchy(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, "/v1")
+	p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -275,9 +275,10 @@ func (f *Filter) Hierarchy(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -311,7 +312,7 @@ func (f *Filter) Hierarchy(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate)
+	p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, "/v1")
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -88,7 +88,7 @@ func TestHierarchyUpdate(t *testing.T) {
 
 			// Set handler and perform call
 			router := mux.NewRouter()
-			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", false)
+			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/update").HandlerFunc(f.HierarchyUpdate)
 			router.ServeHTTP(w, req)
 
@@ -154,7 +154,7 @@ func TestHierarchyUpdate(t *testing.T) {
 
 			// Set handler and perform call
 			router := mux.NewRouter()
-			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", false)
+			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/{code}/update").HandlerFunc(f.HierarchyUpdate)
 			router.ServeHTTP(w, req)
 

--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -137,9 +137,10 @@ func (f *Filter) OutputPage(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_output_id": filterOutputID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_output_id": filterOutputID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -163,10 +164,11 @@ func (f *Filter) OutputPage(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	latestPath := strings.TrimPrefix(latestURL.Path, f.APIRouterVersion)
 
-	p := mapper.CreatePreviewPage(req, dimensions, fj, dataset, filterOutputID, datasetID, ver.ReleaseDate, f.EnableDatasetPreview)
+	p := mapper.CreatePreviewPage(req, dimensions, fj, dataset, filterOutputID, datasetID, ver.ReleaseDate, f.APIRouterVersion, f.EnableDatasetPreview)
 
-	if latestURL.Path == versionURL.Path {
+	if latestPath == versionPath {
 		p.Data.IsLatestVersion = true
 	}
 
@@ -207,7 +209,7 @@ func (f *Filter) OutputPage(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	p.Data.LatestVersion.DatasetLandingPageURL = latestURL.Path
+	p.Data.LatestVersion.DatasetLandingPageURL = latestPath
 	p.Data.LatestVersion.FilterJourneyWithLatestJourney = fmt.Sprintf("/filters/%s/use-latest-version", filterID)
 
 	if len(p.Data.Dimensions) > 0 {

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -104,7 +104,7 @@ func (f *Filter) Search(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), "/v1")
+	p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.APIRouterVersion)
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -59,9 +59,10 @@ func (f *Filter) Search(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -103,7 +104,7 @@ func (f *Filter) Search(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"))
+	p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selVals, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), "/v1")
 
 	b, err := json.Marshal(p)
 	if err != nil {
@@ -158,9 +159,10 @@ func (f *Filter) SearchUpdate(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -45,7 +45,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, "", "", "", "", filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -101,7 +101,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -129,7 +129,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -158,7 +158,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -188,7 +188,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -219,7 +219,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -251,7 +251,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets/abcde/editions/2017/versions/1",
+						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
 			}, nil)
@@ -286,7 +286,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadServiceToken, mockCollectionID, filterID).Return(filter.Model{
 				Links: filter.Links{
 					Version: filter.Link{
-						HRef: "http://localhost:22000/datasets",
+						HRef: "http://localhost:23200/v1/datasets",
 					},
 				},
 			}, nil)

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -61,7 +61,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -84,7 +84,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -111,7 +111,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -140,7 +140,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -170,7 +170,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -201,7 +201,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -233,7 +233,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -267,7 +267,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)
@@ -296,7 +296,7 @@ func TestUnitSearch(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", false)
+			f := NewFilter(mrc, mfc, mdc, nil, msc, nil, mockServiceAuthToken, "", "/v1", false)
 			router.Path("/filters/{filterID}/dimensions/{name}/search").Methods("GET").HandlerFunc(f.Search)
 
 			router.ServeHTTP(w, req)

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/headers"
@@ -232,9 +233,10 @@ func (f *Filter) Time(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
-	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
+	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -282,7 +284,7 @@ func (f *Filter) Time(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p, err := mapper.CreateTimePage(req, fj, dataset, ver, allValues, selValues, dims, datasetID)
+	p, err := mapper.CreateTimePage(req, fj, dataset, ver, allValues, selValues, dims, datasetID, f.APIRouterVersion)
 	if err != nil {
 		log.Event(ctx, "failed to map data to page", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})
 		setStatusCode(req, w, err)

--- a/handlers/update-version.go
+++ b/handlers/update-version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/headers"
 
@@ -47,10 +48,11 @@ func (f *Filter) UseLatest(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, f.APIRouterVersion)
 
-	datasetID, _, _, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL.Path)
+	datasetID, _, _, err := helpers.ExtractDatasetInfoFromPath(ctx, versionPath)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionPath})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -68,10 +70,11 @@ func (f *Filter) UseLatest(w http.ResponseWriter, req *http.Request) {
 		setStatusCode(req, w, err)
 		return
 	}
+	latestPath := strings.TrimPrefix(latestVersionURL.Path, f.APIRouterVersion)
 
 	_, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, latestVersionURL.Path)
 	if err != nil {
-		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": versionURL})
+		log.Event(ctx, "failed to extract dataset info from path", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "path": latestPath})
 		setStatusCode(req, w, err)
 		return
 	}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/ONSdigital/log.go/log"
@@ -18,4 +19,13 @@ func ExtractDatasetInfoFromPath(ctx context.Context, path string) (datasetID, ed
 		return
 	}
 	return subs[1], subs[2], subs[3], nil
+}
+
+// GetAPIRouterVersion returns the path of the provided url, which corresponds to the api router version
+func GetAPIRouterVersion(rawurl string) (string, error) {
+	apiRouterURL, err := url.Parse(rawurl)
+	if err != nil {
+		return "", err
+	}
+	return apiRouterURL.Path, nil
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -25,5 +26,30 @@ func TestUnitHelpers(t *testing.T) {
 			So(edition, ShouldEqual, "")
 			So(version, ShouldEqual, "")
 		})
+	})
+}
+
+func TestGetAPIRouterVersion(t *testing.T) {
+
+	Convey("The api router version is correctly extracted from a valid API Router URL", t, func() {
+		version, err := GetAPIRouterVersion("http://localhost:23200/v1")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "/v1")
+	})
+
+	Convey("An empty string version is extracted from a valid unversioned API Router URL", t, func() {
+		version, err := GetAPIRouterVersion("http://localhost:23200")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "")
+	})
+
+	Convey("Extracting a version from an invalid API Router URL results in the parsing error being returned", t, func() {
+		version, err := GetAPIRouterVersion("hello%goodbye")
+		So(err, ShouldResemble, &url.Error{
+			Op:  "parse",
+			URL: "hello%goodbye",
+			Err: url.EscapeError("%go"),
+		})
+		So(version, ShouldEqual, "")
 	})
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -38,7 +38,7 @@ var topLevelGeographies = map[string]bool{
 
 // CreateFilterOverview maps data items from API responses to form a filter overview
 // front end page model
-func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension, datasetDims dataset.VersionDimensionItems, filter filter.Model, dst dataset.DatasetDetails, filterID, datasetID, releaseDate string) filterOverview.Page {
+func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension, datasetDims dataset.VersionDimensionItems, filter filter.Model, dst dataset.DatasetDetails, filterID, datasetID, releaseDate, apiRouterVersion string) filterOverview.Page {
 	var p filterOverview.Page
 	p.BetaBannerEnabled = true
 
@@ -138,10 +138,11 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 	if err != nil {
 		log.Event(ctx, "unable to parse version url", log.WARN, log.Error(err))
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: dst.Title,
@@ -149,7 +150,7 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -160,7 +161,7 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 
 // CreateListSelectorPage maps items from API responses to form the model for a
 // dimension list selector page
-func CreateListSelectorPage(req *http.Request, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dst dataset.DatasetDetails, dims dataset.VersionDimensions, datasetID, releaseDate string) listSelector.Page {
+func CreateListSelectorPage(req *http.Request, name string, selectedValues []filter.DimensionOption, allValues dataset.Options, filter filter.Model, dst dataset.DatasetDetails, dims dataset.VersionDimensions, datasetID, releaseDate, apiRouterVersion string) listSelector.Page {
 	var p listSelector.Page
 	p.BetaBannerEnabled = true
 
@@ -192,10 +193,11 @@ func CreateListSelectorPage(req *http.Request, name string, selectedValues []fil
 	if err != nil {
 		log.Event(ctx, "unable to parse version url", log.WARN, log.Error(err))
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: dst.Title,
@@ -203,7 +205,7 @@ func CreateListSelectorPage(req *http.Request, name string, selectedValues []fil
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -305,7 +307,7 @@ func CreateListSelectorPage(req *http.Request, name string, selectedValues []fil
 }
 
 // CreatePreviewPage maps data items from API responses to create a preview page
-func CreatePreviewPage(req *http.Request, dimensions []filter.ModelDimension, filter filter.Model, dst dataset.DatasetDetails, filterOutputID, datasetID, releaseDate string, enableDatasetPreivew bool) previewPage.Page {
+func CreatePreviewPage(req *http.Request, dimensions []filter.ModelDimension, filter filter.Model, dst dataset.DatasetDetails, filterOutputID, datasetID, releaseDate, apiRouterVersion string, enableDatasetPreivew bool) previewPage.Page {
 	var p previewPage.Page
 	p.Metadata.Title = "Preview and Download"
 	p.BetaBannerEnabled = true
@@ -325,12 +327,13 @@ func CreatePreviewPage(req *http.Request, dimensions []filter.ModelDimension, fi
 	if err != nil {
 		log.Event(ctx, "unable to parse version url", log.WARN, log.Error(err))
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
-	p.Data.CurrentVersionURL = versionURL.Path
+	p.Data.CurrentVersionURL = versionPath
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: dst.Title,
@@ -338,7 +341,7 @@ func CreatePreviewPage(req *http.Request, dimensions []filter.ModelDimension, fi
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -354,7 +357,7 @@ func CreatePreviewPage(req *http.Request, dimensions []filter.ModelDimension, fi
 	p.DatasetTitle = dst.Title
 	p.Data.DatasetID = datasetID
 	p.DatasetId = datasetID
-	_, p.Data.Edition, _, _ = helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, p.Data.Edition, _, _ = helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	for ext, d := range filter.Downloads {
 		p.Data.Downloads = append(p.Data.Downloads, previewPage.Download{
@@ -395,7 +398,7 @@ func getIDNameLookup(vals dataset.Options) map[string]string {
 }
 
 // CreateAgePage creates an age selector page based on api responses
-func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.VersionDimensions, datasetID string) (age.Page, error) {
+func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.VersionDimensions, datasetID, apiRouterVersion string) (age.Page, error) {
 	var p age.Page
 	p.BetaBannerEnabled = true
 
@@ -417,10 +420,11 @@ func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, 
 	if err != nil {
 		return p, err
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: d.Title,
@@ -428,7 +432,7 @@ func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, 
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -530,7 +534,7 @@ func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, 
 }
 
 // CreateTimePage will create a time selector page based on api response models
-func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.VersionDimensions, datasetID string) (timeModel.Page, error) {
+func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.VersionDimensions, datasetID, apiRouterVersion string) (timeModel.Page, error) {
 	var p timeModel.Page
 	p.BetaBannerEnabled = true
 
@@ -558,10 +562,11 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 	if err != nil {
 		return p, err
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: d.Title,
@@ -569,7 +574,7 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -704,7 +709,7 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 }
 
 // CreateHierarchySearchPage forms a search page based on various api response models
-func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst dataset.DatasetDetails, f filter.Model, selVals []filter.DimensionOption, dims []dataset.VersionDimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query string) hierarchy.Page {
+func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst dataset.DatasetDetails, f filter.Model, selVals []filter.DimensionOption, dims []dataset.VersionDimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query, apiRouterVersion string) hierarchy.Page {
 	var p hierarchy.Page
 	p.BetaBannerEnabled = true
 
@@ -741,11 +746,12 @@ func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst datas
 	if err != nil {
 		log.Event(ctx, "unable to parse version url", log.WARN, log.Error(err))
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
-	p.Data.LandingPageURL = versionURL.Path + "#id-dimensions"
+	p.Data.LandingPageURL = versionPath + "#id-dimensions"
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: dst.Title,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",
@@ -810,7 +816,7 @@ func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst datas
 }
 
 // CreateHierarchyPage maps data items from API responses to form a hirearchy page
-func CreateHierarchyPage(req *http.Request, h hierarchyClient.Model, dst dataset.DatasetDetails, f filter.Model, selVals []filter.DimensionOption, allVals dataset.Options, dims dataset.VersionDimensions, name, curPath, datasetID, releaseDate string) hierarchy.Page {
+func CreateHierarchyPage(req *http.Request, h hierarchyClient.Model, dst dataset.DatasetDetails, f filter.Model, selVals []filter.DimensionOption, allVals dataset.Options, dims dataset.VersionDimensions, name, curPath, datasetID, releaseDate, apiRouterVersion string) hierarchy.Page {
 	var p hierarchy.Page
 	p.BetaBannerEnabled = true
 
@@ -853,10 +859,11 @@ func CreateHierarchyPage(req *http.Request, h hierarchyClient.Model, dst dataset
 	if err != nil {
 		log.Event(ctx, "unable to parse version url", log.WARN, log.Error(err))
 	}
+	versionPath := strings.TrimPrefix(versionURL.Path, apiRouterVersion)
 
 	p.IsInFilterBreadcrumb = true
 
-	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionURL.Path)
+	_, edition, _, _ := helpers.ExtractDatasetInfoFromPath(versionPath)
 
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: dst.Title,
@@ -864,7 +871,7 @@ func CreateHierarchyPage(req *http.Request, h hierarchyClient.Model, dst dataset
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: edition,
-		URI:   versionURL.Path,
+		URI:   versionPath,
 	})
 	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
 		Title: "Filter options",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -20,7 +20,7 @@ func TestUnitMapper(t *testing.T) {
 		filter := getTestFilter()
 		dst := getTestDataset()
 
-		fop := CreateFilterOverview(req, dimensions, datasetDimension, filter, dst, filter.FilterID, "12345", "11-11-1992")
+		fop := CreateFilterOverview(req, dimensions, datasetDimension, filter, dst, filter.FilterID, "12345", "11-11-1992", "/v1")
 		So(fop.FilterID, ShouldEqual, filter.FilterID)
 		So(fop.SearchDisabled, ShouldBeTrue)
 		So(fop.Data.Dimensions, ShouldHaveLength, 5)
@@ -47,8 +47,11 @@ func TestUnitMapper(t *testing.T) {
 		So(fop.Data.Cancel.URL, ShouldEqual, "/")
 		So(fop.Breadcrumb, ShouldHaveLength, 3)
 		So(fop.Breadcrumb[0].Title, ShouldEqual, dst.Title)
+		So(fop.Breadcrumb[0].URI, ShouldEqual, "/datasets//editions")
 		So(fop.Breadcrumb[1].Title, ShouldEqual, "5678")
+		So(fop.Breadcrumb[1].URI, ShouldEqual, "/datasets/1234/editions/5678/versions/1")
 		So(fop.Breadcrumb[2].Title, ShouldEqual, "Filter options")
+		So(fop.Breadcrumb[2].URI, ShouldEqual, "")
 		So(fop.ShowFeedbackForm, ShouldEqual, false)
 	})
 
@@ -57,14 +60,17 @@ func TestUnitMapper(t *testing.T) {
 		filter := getTestFilter()
 		dataset := getTestDataset()
 
-		pp := CreatePreviewPage(req, dimensions, filter, dataset, filter.FilterID, "12345", "11-11-1992", false)
+		pp := CreatePreviewPage(req, dimensions, filter, dataset, filter.FilterID, "12345", "11-11-1992", "/v1", false)
 		So(pp.SearchDisabled, ShouldBeFalse)
 		So(pp.Breadcrumb, ShouldHaveLength, 4)
 		So(pp.Breadcrumb[0].Title, ShouldEqual, dataset.Title)
+		So(pp.Breadcrumb[0].URI, ShouldEqual, "/datasets//editions")
 		So(pp.Breadcrumb[1].Title, ShouldEqual, "5678")
+		So(pp.Breadcrumb[1].URI, ShouldEqual, "/datasets/1234/editions/5678/versions/1")
 		So(pp.Breadcrumb[2].Title, ShouldEqual, "Filter options")
 		So(pp.Breadcrumb[2].URI, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
 		So(pp.Breadcrumb[3].Title, ShouldEqual, "Preview")
+		So(pp.Breadcrumb[3].URI, ShouldEqual, "")
 		So(pp.Data.FilterID, ShouldEqual, filter.Links.FilterBlueprint.ID)
 		So(pp.ShowFeedbackForm, ShouldEqual, true)
 		if pp.Data.Downloads[0].Extension == "csv" {
@@ -113,17 +119,20 @@ func TestUnitMapper(t *testing.T) {
 
 			filter := getTestFilter()
 
-			p := CreateListSelectorPage(req, "time", selectedValues, allValues, filter, d, dataset.VersionDimensions{}, "12345", "11-11-1992")
+			p := CreateListSelectorPage(req, "time", selectedValues, allValues, filter, d, dataset.VersionDimensions{}, "12345", "11-11-1992", "/v1")
 			So(p.Data.Title, ShouldEqual, "Time")
 			So(p.SearchDisabled, ShouldBeTrue)
 			So(p.FilterID, ShouldEqual, filter.FilterID)
 
 			So(p.Breadcrumb, ShouldHaveLength, 4)
 			So(p.Breadcrumb[0].Title, ShouldEqual, d.Title)
+			So(p.Breadcrumb[0].URI, ShouldEqual, "/datasets//editions")
 			So(p.Breadcrumb[1].Title, ShouldEqual, "5678")
+			So(p.Breadcrumb[1].URI, ShouldEqual, "/datasets/1234/editions/5678/versions/1")
 			So(p.Breadcrumb[2].Title, ShouldEqual, "Filter options")
 			So(p.Breadcrumb[2].URI, ShouldEqual, "/filters/"+filter.Links.FilterBlueprint.ID+"/dimensions")
 			So(p.Breadcrumb[3].Title, ShouldEqual, "Time")
+			So(p.Breadcrumb[3].URI, ShouldEqual, "")
 			So(p.Data.AddFromRange.Label, ShouldEqual, "add time range")
 			So(p.Data.AddFromRange.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions/time")
 			So(p.Data.SaveAndReturn.URL, ShouldEqual, "/filters/"+filter.FilterID+"/dimensions")
@@ -158,7 +167,7 @@ func TestUnitMapper(t *testing.T) {
 						Label: "2017",
 					},
 				},
-			}, filter.Model{}, dataset.DatasetDetails{}, dataset.VersionDimensions{}, "1234", "today")
+			}, filter.Model{}, dataset.DatasetDetails{}, dataset.VersionDimensions{}, "1234", "today", "/v1")
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 
@@ -184,7 +193,7 @@ func TestUnitMapper(t *testing.T) {
 						Label: "Ireland",
 					},
 				},
-			}, filter.Model{}, dataset.DatasetDetails{}, dataset.VersionDimensions{}, "1234", "today")
+			}, filter.Model{}, dataset.DatasetDetails{}, dataset.VersionDimensions{}, "1234", "today", "/v1")
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 
@@ -252,7 +261,7 @@ func getTestFilter() filter.Model {
 		Version:   "2017",
 		Links: filter.Links{
 			Version: filter.Link{
-				HRef: "/datasets/1234/editions/5678/versions/1",
+				HRef: "/v1/datasets/1234/editions/5678/versions/1",
 			},
 			FilterBlueprint: filter.Link{
 				ID: "12349876",

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/search"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
 	"github.com/ONSdigital/go-ns/validator"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -43,8 +44,13 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 		log.Event(ctx, "failed to validate date rules", log.WARN, log.Error(err))
 	}
 
+	apiRouterVersion, err := helpers.GetAPIRouterVersion(cfg.APIRouterURL)
+	if err != nil {
+		log.Event(ctx, "failed to obtain an api router version. Will assume that it is un-versioned", log.WARN, log.Error(err))
+	}
+
 	filter := handlers.NewFilter(clients.Renderer, clients.Filter, clients.Dataset,
-		clients.Hierarchy, clients.Search, v, cfg.SearchAPIAuthToken, cfg.DownloadServiceURL,
+		clients.Hierarchy, clients.Search, v, cfg.SearchAPIAuthToken, cfg.DownloadServiceURL, apiRouterVersion,
 		cfg.EnableDatasetPreview)
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(clients.HealthcheckHandler)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -249,7 +249,7 @@ func TestClose(t *testing.T) {
 			timeoutServerMock := &mock.HTTPServerMock{
 				ListenAndServeFunc: func() error { return nil },
 				ShutdownFunc: func(ctx context.Context) error {
-					time.Sleep(2 * time.Millisecond)
+					time.Sleep(5 * time.Millisecond)
 					return nil
 				},
 			}


### PR DESCRIPTION
# What

- Extract API Router Version from API Router URL in config
- In links returned in the response, trim the version prefix if it exists.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone