### PR TITLE
Hotfix/hierarchy

### DIFF
--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -296,9 +296,8 @@ func (f *Filter) isHierarchicalDimension(ctx context.Context, instanceID, dimens
 		log.Event(ctx, "error getting hierarchy root", logD, log.WARN, log.Error(err))
 
 		var getHierarchyErr hierarchy.ErrInvalidHierarchyAPIResponse
-		if errors.Is(err, &getHierarchyErr) && http.StatusNotFound == getHierarchyErr.Code() {
-
-			log.Event(ctx, "dimension is not hierarchy ignoring error and continuing", logD, log.INFO)
+		if errors.As(err, &getHierarchyErr) && http.StatusNotFound == getHierarchyErr.Code() {
+			log.Event(ctx, "dimension is not hierarchical value ignoring error and continuing", logD, log.INFO)
 			return false, nil
 		}
 


### PR DESCRIPTION
### What

Fixed incorrect error handling logic for custom type. If error is a hierarchy error type - cast and check the status code value to determine if its a "OK error" or and "error error"
