### PR TITLE
New time filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.30.0
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.10.1-0.20200813150831-2a0297570ab5
-	github.com/ONSdigital/dp-frontend-models v1.5.0
+	github.com/ONSdigital/dp-frontend-models v1.8.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.9
 	github.com/ONSdigital/go-ns v0.0.0-20200511161740-afc39066ee62

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ONSdigital/dp-frontend-dataset-controller v1.10.1-0.20200813150831-2a
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-frontend-models v1.5.0 h1:FZngursXY984WuCW5x4+VzyDOkoEUQleh3OT4/w1NNU=
 github.com/ONSdigital/dp-frontend-models v1.5.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.8.0 h1:GnSO18hvjNGDblxNIEATXhGz32DO+H9eshkCAcbjFQY=
+github.com/ONSdigital/dp-frontend-models v1.8.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -116,7 +116,6 @@ func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req
 		}
 	}
 
-	var selectedMonths []string
 	var options []string
 	startYearStr := req.Form.Get("start-year-grouped")
 	endYearStr := req.Form.Get("end-year-grouped")
@@ -131,18 +130,12 @@ func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req
 		return err
 	}
 
-	for k := range req.Form {
-		if _, err := time.Parse("January", k); err != nil {
-			continue
-		}
-		selectedMonths = append(selectedMonths, k)
-	}
+	selectedMonths := req.Form["months"]
 
 	for year := startYearInt; year <= endYearInt; year++ {
 		yearStr := strconv.Itoa(year)
 		for _, month := range selectedMonths {
-			monthYearComboArr := []string{month, yearStr}
-			monthYearComboStr := strings.Join(monthYearComboArr, " ")
+			monthYearComboStr  := fmt.Sprintf("%s %s", month, yearStr)
 			monthYearComboTime, err := time.Parse("January 2006", monthYearComboStr)
 			if err != nil {
 				log.Event(ctx, "failed to convert filtered month and year combo to time format", log.ERROR, log.Error(err))

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/ONSdigital/dp-api-clients-go/filter"
+	dprequest "github.com/ONSdigital/dp-net/request"
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUpdateTime(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ctx := gomock.Any()
+	options := gomock.Any()
+	const mockUserAuthToken = "Foo"
+	const mockServiceAuthToken = ""
+	const mockCollectionID = "Bar"
+	const mockFilterID = ""
+	Convey("test update time function", t, func() {
+		Convey("given a valid list of options there should be no errors but be a redirect", func() {
+			mockClient := NewMockFilterClient(mockCtrl)
+			mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
+			mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
+			mockClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return([]filter.DimensionOption{}, nil)
+			mockClient.EXPECT().AddDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", options).Return(nil) // Might not be able to use gomock.Any() here
+			target := fmt.Sprintf("/filters/%s/dimensions/time/update", mockFilterID)
+			formData := "latest-option=Nov-17&latest-month=November&latest-year=2017&month-single=Select&year-single=Select&start-month=Select&start-year=Select&end-month=Select&end-year=Select&time-selection=list&August=August&start-year-grouped=2011&end-year-grouped=2012&save-and-return=Save+and+return"
+			reader := strings.NewReader(formData)
+			req := httptest.NewRequest("POST", target, reader)
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Add(dprequest.FlorenceHeaderKey, mockUserAuthToken)
+			req.Header.Add(dprequest.CollectionIDHeaderKey, mockCollectionID)
+			w := httptest.NewRecorder()
+			f := NewFilter(nil, mockClient, nil, nil, nil, nil, mockServiceAuthToken, "", "/v1", false)
+			f.UpdateTime().ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, 302)
+
+		})
+	})
+}

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -29,7 +29,7 @@ func TestUpdateTime(t *testing.T) {
 			mockClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return([]filter.DimensionOption{}, nil)
 			mockClient.EXPECT().AddDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", options).Return(nil) // Might not be able to use gomock.Any() here
 			target := fmt.Sprintf("/filters/%s/dimensions/time/update", mockFilterID)
-			formData := "latest-option=Nov-17&latest-month=November&latest-year=2017&month-single=Select&year-single=Select&start-month=Select&start-year=Select&end-month=Select&end-year=Select&time-selection=list&August=August&start-year-grouped=2011&end-year-grouped=2012&save-and-return=Save+and+return"
+			formData := "latest-option=Nov-17&latest-month=November&latest-year=2017&month-single=Select&year-single=Select&start-month=Select&start-year=Select&end-month=Select&end-year=Select&time-selection=list&months=August&start-year-grouped=2011&end-year-grouped=2012&save-and-return=Save+and+return"
 			reader := strings.NewReader(formData)
 			req := httptest.NewRequest("POST", target, reader)
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -29,3 +29,13 @@ func GetAPIRouterVersion(rawurl string) (string, error) {
 	}
 	return apiRouterURL.Path, nil
 }
+
+// StringInSlice will check if a string is in a slice and return a corresponding boolean value
+func StringInSlice(str string, slice []string) bool {
+	for _, sliceStr := range slice {
+		if sliceStr == str {
+			return true
+		}
+	}
+	return false
+}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -30,12 +30,13 @@ func GetAPIRouterVersion(rawurl string) (string, error) {
 	return apiRouterURL.Path, nil
 }
 
-// StringInSlice will check if a string is in a slice and return a corresponding boolean value
-func StringInSlice(str string, slice []string) bool {
-	for _, sliceStr := range slice {
+// StringInSlice will check if a string is in a slice and return a corresponding boolean value along with the
+// first index it was found at. If not present then it will return false and negative -1
+func StringInSlice(str string, slice []string) (int, bool) {
+	for i, sliceStr := range slice {
 		if sliceStr == str {
-			return true
+			return i, true
 		}
 	}
-	return false
+	return -1, false
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -53,3 +53,77 @@ func TestGetAPIRouterVersion(t *testing.T) {
 		So(version, ShouldEqual, "")
 	})
 }
+
+// TestStringInSlice tests the helper function TestStringInSlice
+func TestStringInSlice(t *testing.T) {
+	Convey("given a slice", t, func() {
+		subjectSlice := []string{"foo", "Bar", "bAz", "quX", "QUUX", "COrGE", "gRaUlT", "GaRpLy", "WALdo", "frED", "pl ugh", "xyzzy1", "thud-", ""}
+		Convey("and a string that the slice contains it should find said string", func() {
+			testString := "foo"
+			isFound := StringInSlice(testString, subjectSlice)
+			So(isFound, ShouldEqual, true)
+			Convey("it should be case sensitive and only yield true for exact matches", func() {
+				testString = "Bar"
+				isFound = StringInSlice(testString, subjectSlice)
+				So(isFound, ShouldEqual, true)
+				Convey("even if there is a random case difference in the middle of the string", func() {
+					testString = "bAz"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, true)
+				})
+				Convey("or a space", func() {
+					testString = "pl ugh"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, true)
+				})
+				Convey("or a numerical value represented as a char", func() {
+					testString = "xyzzy1"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, true)
+				})
+				Convey("or a symbolic character represented as a char", func() {
+					testString = "thud-"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, true)
+				})
+				Convey("or even a completely empty string", func() {
+					testString = ""
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, true)
+				})
+			})
+			Convey("it should be case sensitive and yield false for any other value", func() {
+				Convey("like if the initial capital letter isn't considered", func() {
+					testString = "bar"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+				Convey("or a random capital in the middle of the string isn't considered", func() {
+					testString = "baz"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+				Convey("or a space in a string is missing", func() {
+					testString = "plugh"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+				Convey("or a numeral represented as a string char is missing", func() {
+					testString = "xyzzy"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+				Convey("or a symbol represented as a char is missing", func() {
+					testString = "thud"
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+				Convey("or if a space char slips in and shouldn't be there", func() {
+					testString = " "
+					isFound = StringInSlice(testString, subjectSlice)
+					So(isFound, ShouldEqual, false)
+				})
+			})
+		})
+	})
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -57,71 +57,91 @@ func TestGetAPIRouterVersion(t *testing.T) {
 // TestStringInSlice tests the helper function TestStringInSlice
 func TestStringInSlice(t *testing.T) {
 	Convey("given a slice", t, func() {
-		subjectSlice := []string{"foo", "Bar", "bAz", "quX", "QUUX", "COrGE", "gRaUlT", "GaRpLy", "WALdo", "frED", "pl ugh", "xyzzy1", "thud-", ""}
+		subjectSlice := []string{"foo", "Bar", "bAz", "quX", "QUUX", "COrGE", "gRaUlT", "GaRpLy", "WALdo", "frED", "pl ugh", "xyzzy1", "thud-", "", "gRaUlT"}
 		Convey("and a string that the slice contains it should find said string", func() {
 			testString := "foo"
-			isFound := StringInSlice(testString, subjectSlice)
+			index, isFound := StringInSlice(testString, subjectSlice)
 			So(isFound, ShouldEqual, true)
+			So(index, ShouldEqual, 0)
 			Convey("it should be case sensitive and only yield true for exact matches", func() {
 				testString = "Bar"
-				isFound = StringInSlice(testString, subjectSlice)
+				index, isFound = StringInSlice(testString, subjectSlice)
 				So(isFound, ShouldEqual, true)
+				So(index, ShouldEqual, 1)
 				Convey("even if there is a random case difference in the middle of the string", func() {
 					testString = "bAz"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, true)
+					So(index, ShouldEqual, 2)
 				})
 				Convey("or a space", func() {
 					testString = "pl ugh"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, true)
+					So(index, ShouldEqual, 10)
 				})
 				Convey("or a numerical value represented as a char", func() {
 					testString = "xyzzy1"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, true)
+					So(index, ShouldEqual, 11)
 				})
 				Convey("or a symbolic character represented as a char", func() {
 					testString = "thud-"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, true)
+					So(index, ShouldEqual, 12)
 				})
 				Convey("or even a completely empty string", func() {
 					testString = ""
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, true)
+					So(index, ShouldEqual, 13)
 				})
+			})
+			Convey("it should return the index of the first found position in the array if there are multiple", func() {
+				testString = "gRaUlT"
+				index, isFound = StringInSlice(testString, subjectSlice)
+				So(isFound, ShouldEqual, true)
+				So(index, ShouldEqual, 6)
 			})
 			Convey("it should be case sensitive and yield false for any other value", func() {
 				Convey("like if the initial capital letter isn't considered", func() {
 					testString = "bar"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
 				})
 				Convey("or a random capital in the middle of the string isn't considered", func() {
 					testString = "baz"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
 				})
 				Convey("or a space in a string is missing", func() {
 					testString = "plugh"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
 				})
 				Convey("or a numeral represented as a string char is missing", func() {
 					testString = "xyzzy"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
+
 				})
 				Convey("or a symbol represented as a char is missing", func() {
 					testString = "thud"
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
 				})
 				Convey("or if a space char slips in and shouldn't be there", func() {
 					testString = " "
-					isFound = StringInSlice(testString, subjectSlice)
+					index, isFound = StringInSlice(testString, subjectSlice)
 					So(isFound, ShouldEqual, false)
+					So(index, ShouldEqual, -1)
 				})
 			})
 		})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -719,7 +719,8 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 			continue
 		}
 		monthStr := month.Format("January")
-		if !fdHelpers.StringInSlice(monthStr, selectedMonths) {
+		_, found := fdHelpers.StringInSlice(monthStr, selectedMonths)
+		if !found {
 			selectedMonths = append(selectedMonths, monthStr)
 		}
 		yearStr := month.Format("2006")
@@ -730,8 +731,20 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 			maxYear = yearStr
 		}
 		yearInt, err := strconv.Atoi(yearStr)
+		if err != nil{
+			log.Event(ctx, "unable to convert year string to int for comparison", log.ERROR, log.Error(err))
+			continue
+		}
 		maxYearInt, err := strconv.Atoi(maxYear)
+		if err != nil{
+			log.Event(ctx, "unable to convert max year string to int for comparison", log.ERROR, log.Error(err))
+			continue
+		}
 		minYearInt, err := strconv.Atoi(minYear)
+		if err != nil{
+			log.Event(ctx, "unable to convert min year string to int for comparison", log.ERROR, log.Error(err))
+			continue
+		}
 		if yearInt > maxYearInt {
 			maxYear = yearStr
 		} else if yearInt < minYearInt {
@@ -739,11 +752,13 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 		}
 	}
 	var listOfAllMonths []timeModel.Month
-	for i := 0; i < 12; i++ {
+	numberOfMonthsInAYear := 12
+	for i := 0; i < numberOfMonthsInAYear; i++ {
 		monthName := time.Month(i + 1).String()
+		_, isSelected := fdHelpers.StringInSlice(monthName, selectedMonths)
 		singleMonth := timeModel.Month{
 			Name:       monthName,
-			IsSelected: fdHelpers.StringInSlice(monthName, selectedMonths),
+			IsSelected: isSelected,
 		}
 		listOfAllMonths = append(listOfAllMonths, singleMonth)
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ONSdigital/dp-cookies/cookies"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dates"
+	fdHelpers "github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
+
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/age"
 	"github.com/ONSdigital/dp-frontend-models/model/dataset-filter/filterOverview"
@@ -545,7 +547,6 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 	mapCookiePreferences(req, &p.CookiesPreferencesSet, &p.CookiesPolicy)
 
 	ctx := req.Context()
-	log.Event(ctx, "mapping api responses to time page model", log.INFO, log.Data{"filterID": f.FilterID, "datasetID": datasetID})
 
 	if _, err := time.Parse("Jan-06", allVals.Items[0].Option); err == nil {
 		p.Data.Type = "month"
@@ -709,6 +710,49 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 		p.Data.SelectedEndMonth = selDates[len(selDates)-1].Month().String()
 		p.Data.SelectedEndYear = fmt.Sprintf("%d", selDates[len(selDates)-1].Year())
 	}
+	var minYear, maxYear string
+	var selectedMonths []string
+	for _, selVal := range selVals {
+		month, err := time.Parse("Jan-06", selVal.Option)
+		if err != nil {
+			log.Event(ctx, "unable to convert date to month value", log.ERROR, log.Error(err))
+			continue
+		}
+		monthStr := month.Format("January")
+		if !fdHelpers.StringInSlice(monthStr, selectedMonths) {
+			selectedMonths = append(selectedMonths, monthStr)
+		}
+		yearStr := month.Format("2006")
+		if minYear == "" {
+			minYear = yearStr
+		}
+		if maxYear == "" {
+			maxYear = yearStr
+		}
+		yearInt, err := strconv.Atoi(yearStr)
+		maxYearInt, err := strconv.Atoi(maxYear)
+		minYearInt, err := strconv.Atoi(minYear)
+		if yearInt > maxYearInt {
+			maxYear = yearStr
+		} else if yearInt < minYearInt {
+			minYear = yearStr
+		}
+	}
+	var listOfAllMonths []timeModel.Month
+	for i := 0; i < 12; i++ {
+		monthName := time.Month(i + 1).String()
+		singleMonth := timeModel.Month{
+			Name:       monthName,
+			IsSelected: fdHelpers.StringInSlice(monthName, selectedMonths),
+		}
+		listOfAllMonths = append(listOfAllMonths, singleMonth)
+	}
+	GroupedSelection := timeModel.GroupedSelection{
+		Months:    listOfAllMonths,
+		YearStart: minYear,
+		YearEnd:   maxYear,
+	}
+	p.Data.GroupedSelection = GroupedSelection
 
 	return p, nil
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1,14 +1,15 @@
 package mapper
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
 	"github.com/ONSdigital/dp-frontend-models/model"
+	timeModel "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/time"
+	dprequest "github.com/ONSdigital/dp-net/request"
 	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestUnitMapper(t *testing.T) {
@@ -231,6 +232,67 @@ func getTestDimensions() []filter.ModelDimension {
 	}
 }
 
+func getTestDatasetOptions() dataset.Options {
+	return dataset.Options{Items: []dataset.Option{
+		{
+			DimensionID: "time",
+			Label:       "Apr-05",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
+					ID:  "mmm-yy",
+				},
+				Version: dataset.Link{
+					URL: "http://api.localhost:23200/v1/datasets/cpih01/editions/time-series/versions/7",
+					ID:  "7",
+				},
+				Code: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy/codes/Month",
+					ID:  "Month",
+				},
+			},
+			Option: "Apr-05",
+		},
+		{
+			DimensionID: "time",
+			Label:       "Apr-06",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
+					ID:  "mmm-yy",
+				},
+				Version: dataset.Link{
+					URL: "http://api.localhost:23200/v1/datasets/cpih01/editions/time-series/versions/7",
+					ID:  "7",
+				},
+				Code: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy/codes/Month",
+					ID:  "Month",
+				},
+			},
+			Option: "Apr-06",
+		},
+		{
+			DimensionID: "time",
+			Label:       "Apr-07",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
+					ID:  "mmm-yy",
+				},
+				Version: dataset.Link{
+					URL: "http://api.localhost:23200/v1/datasets/cpih01/editions/time-series/versions/7",
+					ID:  "7",
+				},
+				Code: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy/codes/Month",
+					ID:  "Month",
+				},
+			},
+			Option: "Apr-07",
+		}}}
+}
+
 func getTestDatasetDimensions() []dataset.VersionDimension {
 	return []dataset.VersionDimension{
 		{
@@ -315,4 +377,99 @@ func TestUnitMapCookiesPreferences(t *testing.T) {
 		So(pageModel.CookiesPolicy.Essential, ShouldEqual, true)
 		So(pageModel.CookiesPolicy.Usage, ShouldEqual, true)
 	})
+}
+
+func TestCreateTimePage(t *testing.T) {
+	Convey("maps filter to page model correctly", t, func() {
+		desiredPageModel := timeModel.Page{
+			Page: model.Page{},
+			Data: timeModel.Data{
+				LatestTime:         timeModel.Value{},
+				FirstTime:          timeModel.Value{},
+				Values:             nil,
+				Months:             []string{"Select", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
+				Years:              []string{"Select", "2005", "2006", "2007"},
+				CheckedRadio:       "",
+				FormAction:         timeModel.Link{},
+				SelectedStartMonth: "",
+				SelectedStartYear:  "",
+				SelectedEndMonth:   "",
+				SelectedEndYear:    "",
+				Type:               "",
+				DatasetTitle:       "",
+				GroupedSelection: timeModel.GroupedSelection{
+					Months: []timeModel.Month{
+						{
+							Name:       "January",
+							IsSelected: false,
+						},
+						{
+							Name:       "February",
+							IsSelected: false,
+						},
+						{
+							Name:       "March",
+							IsSelected: false,
+						},
+						{
+							Name:       "April",
+							IsSelected: false,
+						},
+						{
+							Name:       "May",
+							IsSelected: false,
+						},
+						{
+							Name:       "June",
+							IsSelected: false,
+						},
+						{
+							Name:       "July",
+							IsSelected: false,
+						},
+						{
+							Name:       "August",
+							IsSelected: false,
+						},
+						{
+							Name:       "September",
+							IsSelected: false,
+						},
+						{
+							Name:       "October",
+							IsSelected: false,
+						},
+						{
+							Name:       "November",
+							IsSelected: false,
+						},
+						{
+							Name:       "December",
+							IsSelected: false,
+						},
+					},
+					YearStart: "",
+					YearEnd:   "",
+				},
+			},
+			FilterID: "",
+		}
+		req := httptest.NewRequest("", "/", nil)
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		// Never actually used in the mapper but func requires it so leaving blank until needed in a test
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetOptions()
+		dimensionOptions := []filter.DimensionOption{{}}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+		datasetID := "cpih01"
+		apiRouterVersion := "v1"
+		lang := dprequest.DefaultLang
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, dimensionOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage.Data.GroupedSelection, ShouldResemble, desiredPageModel.Data.GroupedSelection)
+		So(timeModelPage.Data.Months, ShouldResemble, desiredPageModel.Data.Months)
+		So(timeModelPage.Data.Years, ShouldResemble, desiredPageModel.Data.Years)
+	})
+
 }


### PR DESCRIPTION
### What

- New filter option added that is more accessible
 - Squashes form data into the old filter-api format for storage
 - Maps the filter-api responses to fulfil the new page model around time selection
- Tests added (but only around work added)
- Models updated
- Work completed under the assumption that all CMD 'time' fields are monthly (can see there is a type in the model declared but is always populated with 'monthly' no matter the dataset.

### How to review

Check that the whole filter journey works, and that other filters have not broken (especially those involving time as a filter option)

Review in conjunction with:
- https://github.com/ONSdigital/sixteens/pull/244
- https://github.com/ONSdigital/dp-frontend-models/pull/73
- https://github.com/ONSdigital/dp-frontend-renderer/pull/513

### Who can review

Anyone except me
