### PR TITLE
Feature/remove get options

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -3,13 +3,11 @@ package handlers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/filter"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // these form vars are not regular input fields, but transmit meta form info
@@ -68,7 +66,7 @@ func (f *Filter) getIDNameLookupFromDatasetAPI(ctx context.Context, userAccessTo
 			totalCount = options.TotalCount
 		}
 
-		// iterate bath items and found values options and labels
+		// iterate items in batch and populate labels in idLabelMap
 		for _, opt := range options.Items {
 			if _, found := idLabelMap[opt.Option]; found {
 				idLabelMap[opt.Option] = opt.Label
@@ -87,34 +85,4 @@ func (f *Filter) getIDNameLookupFromDatasetAPI(ctx context.Context, userAccessTo
 
 	// return error because some value(s) could not be found
 	return idLabelMap, errors.New("could not find all required filter options in dataset API")
-}
-
-// -- TESTING UTILITIES
-
-// go-mock tailored matcher to compare lists of strings ignoring order
-type itemsEq struct{ expected []string }
-
-// ItemsEq checks if 2 slices contain the same items in any order
-func ItemsEq(expected []string) gomock.Matcher {
-	return &itemsEq{expected}
-}
-
-func (i *itemsEq) Matches(x interface{}) bool {
-	if len(x.([]string)) != len(i.expected) {
-		return false
-	}
-	mExpected := make(map[string]struct{})
-	for _, e := range i.expected {
-		mExpected[e] = struct{}{}
-	}
-	for _, val := range x.([]string) {
-		if _, found := mExpected[val]; !found {
-			return false
-		}
-	}
-	return true
-}
-
-func (i *itemsEq) String() string {
-	return fmt.Sprintf("%v (in any order)", i.expected)
 }

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/filter"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -36,6 +39,57 @@ func getOptionsAndRedirect(form url.Values, redirectURI *string) (options []stri
 	}
 	return options
 }
+
+// getIDNameLookupFromDatasetAPI creates a map of option keys and labels from the provided filter options,
+// getting the labels from DatasetAPI with paginated calls until all values have been found.
+// Note that this method may be expensive, if you can get the labels from some other available source, it would be preferred.
+func (f *Filter) getIDNameLookupFromDatasetAPI(ctx context.Context, userAccessToken, collectionID, datasetID, edition, version, name string,
+	filterOptions filter.DimensionOptions) (idLabelMap map[string]string, err error) {
+
+	// initialise map of options to find, allocating empty strings for all values.
+	idLabelMap = make(map[string]string, len(filterOptions.Items))
+	for _, option := range filterOptions.Items {
+		idLabelMap[option.Option] = ""
+	}
+
+	// call datasetAPI GetOptions with pagination until we find all values
+	offset := 0
+	totalCount := 1
+	foundCount := 0
+	for offset < totalCount {
+		// get options batch from dataset API
+		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, offset, f.BatchSize)
+		if err != nil {
+			return idLabelMap, err
+		}
+
+		// (first iteration only) - set totalCount
+		if offset == 0 {
+			totalCount = options.TotalCount
+		}
+
+		// iterate bath items and found values options and labels
+		for _, opt := range options.Items {
+			if _, found := idLabelMap[opt.Option]; found {
+				idLabelMap[opt.Option] = opt.Label
+				foundCount++
+			}
+		}
+
+		// return if we have found all the required options
+		if foundCount == len(idLabelMap) {
+			return idLabelMap, nil
+		}
+
+		// set offset for the next iteration
+		offset += f.BatchSize
+	}
+
+	// return error because some value(s) could not be found
+	return idLabelMap, errors.New("could not find all required filter options in dataset API")
+}
+
+// -- TESTING UTILITIES
 
 // go-mock tailored matcher to compare lists of strings ignoring order
 type itemsEq struct{ expected []string }

--- a/handlers/common_test.go
+++ b/handlers/common_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
@@ -165,4 +166,32 @@ func slice(full []dataset.Option, offset, limit int) (sliced []dataset.Option) {
 	}
 
 	return full[offset:end]
+}
+
+// go-mock tailored matcher to compare lists of strings ignoring order
+type itemsEq struct{ expected []string }
+
+// ItemsEq checks if 2 slices contain the same items in any order
+func ItemsEq(expected []string) gomock.Matcher {
+	return &itemsEq{expected}
+}
+
+func (i *itemsEq) Matches(x interface{}) bool {
+	if len(x.([]string)) != len(i.expected) {
+		return false
+	}
+	mExpected := make(map[string]struct{})
+	for _, e := range i.expected {
+		mExpected[e] = struct{}{}
+	}
+	for _, val := range x.([]string) {
+		if _, found := mExpected[val]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (i *itemsEq) String() string {
+	return fmt.Sprintf("%v (in any order)", i.expected)
 }

--- a/handlers/common_test.go
+++ b/handlers/common_test.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/filter"
+	gomock "github.com/golang/mock/gomock"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+	mockUserAuthToken := "testUserAuthToken"
+	mockServiceAuthToken := "testServiceAuthToken"
+	mockCollectionID := "testCollectionID"
+
+	datasetID := "abcde"
+	name := "aggregate"
+	edition := "2017"
+	version := "1"
+
+	Convey("Given a filter initialised with a mocked DatasetClient ", t, func() {
+		mdc := NewMockDatasetClient(mockCtrl)
+
+		Convey("a set of existing filter dimension options is correctly mapped to lables returned by dataset API GetOptions", func() {
+			batchSize := 100
+			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			filterOptions := filter.DimensionOptions{
+				Items: []filter.DimensionOption{
+					{Option: "op1"},
+					{Option: "op2"},
+				},
+			}
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
+			So(err, ShouldBeNil)
+			So(idLabelMap, ShouldResemble, map[string]string{
+				"op1": "This is option 1",
+				"op2": "This is option 2",
+			})
+		})
+
+		Convey("a set of existing filter dimension options is correctly mapped to lables returned by dataset API GetOptions in multiple batches", func() {
+			batchSize := 3
+			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			filterOptions := filter.DimensionOptions{
+				Items: []filter.DimensionOption{
+					{Option: "op1"}, // belongs to first batch
+					{Option: "op4"}, // belongs to second batch
+					{Option: "op5"}, // belongs to second batch
+				},
+			}
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, batchSize, batchSize).Return(datasetOptions(batchSize, batchSize), nil)
+			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
+			So(err, ShouldBeNil)
+			So(idLabelMap, ShouldResemble, map[string]string{
+				"op1": "This is option 1",
+				"op4": "This is option 4",
+				"op5": "This is option 5",
+			})
+		})
+
+		Convey("a set of existing filter dimension options is correctly mapped to lables returned by dataset API GetOptions and no further batches are executed if all items have been found", func() {
+			batchSize := 3
+			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			filterOptions := filter.DimensionOptions{
+				Items: []filter.DimensionOption{
+					{Option: "op1"}, // belongs to first batch
+					{Option: "op2"}, // belongs to first batch
+				},
+			}
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
+			So(err, ShouldBeNil)
+			So(idLabelMap, ShouldResemble, map[string]string{
+				"op1": "This is option 1",
+				"op2": "This is option 2",
+			})
+		})
+
+		Convey("a set of filter dimension options containing inexistent options returns the expected error, but the existing dimensions are correctly mapped", func() {
+			batchSize := 100
+			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			filterOptions := filter.DimensionOptions{
+				Items: []filter.DimensionOption{
+					{Option: "op1"},
+					{Option: "inexistent"},
+				},
+			}
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			expectedErr := errors.New("could not find all required filter options in dataset API")
+			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
+			So(err, ShouldResemble, expectedErr)
+			So(idLabelMap, ShouldResemble, map[string]string{
+				"op1":        "This is option 1",
+				"inexistent": "",
+			})
+		})
+
+		Convey("if dataset API GetOptions returns an error, the same error is returned and the next batch is not requested", func() {
+			batchSize := 2
+			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			filterOptions := filter.DimensionOptions{
+				Items: []filter.DimensionOption{{Option: "op1"}},
+			}
+			expectedErr := errors.New("error getting options from Dataset API")
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, expectedErr)
+			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
+			So(err, ShouldResemble, expectedErr)
+			So(idLabelMap, ShouldResemble, map[string]string{"op1": ""})
+		})
+	})
+}
+
+// datasetOptions returns a mocked dataset.Options struct according to the provided offset and limit
+func datasetOptions(offset, limit int) dataset.Options {
+	allItems := []dataset.Option{
+		{
+			Label:  "This is option 1",
+			Option: "op1",
+		},
+		{
+			Label:  "This is option 2",
+			Option: "op2",
+		},
+		{
+			Label:  "This is option 3",
+			Option: "op3",
+		},
+		{
+			Label:  "This is option 4",
+			Option: "op4",
+		},
+		{
+			Label:  "This is option 5",
+			Option: "op5",
+		},
+	}
+	o := dataset.Options{
+		Offset:     offset,
+		Limit:      limit,
+		TotalCount: len(allItems),
+	}
+	o.Items = slice(allItems, offset, limit)
+	o.Count = len(o.Items)
+	return o
+}
+
+func slice(full []dataset.Option, offset, limit int) (sliced []dataset.Option) {
+	end := offset + limit
+	if limit == 0 || end > len(full) {
+		end = len(full)
+	}
+
+	if offset > len(full) {
+		return []dataset.Option{}
+	}
+
+	return full[offset:end]
+}

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -26,15 +26,33 @@ func TestUnitFilterOverview(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	Convey("test FilterOverview", t, func() {
+
+		datasetGeographyOptions := dataset.Options{
+			Items: []dataset.Option{
+				{
+					DimensionID: "geography",
+					Label:       "UK",
+				},
+			},
+			Count:      1,
+			TotalCount: 1,
+			Offset:     0,
+			Limit:      batchSize,
+		}
+
 		Convey("test FilterOverview can successfully load a page", func() {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
-			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{filter.Dimension{Name: "Day"}, filter.Dimension{Name: "Goods and Services"}}, nil)
+			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, 0).Return(filter.DimensionOptions{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", 0, 0).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, 0).Return(filter.DimensionOptions{}, nil)
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
-			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{Items: []dataset.VersionDimension{{Name: "geography"}}}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", 0, 0)
+			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{
+				Items: []dataset.VersionDimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and services"}, {Name: "unused"}}}, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", 0, batchSize).Return(datasetGeographyOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Day", 0, batchSize).Return(dataset.Options{}, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Goods and Services", 0, batchSize).Return(dataset.Options{}, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}}, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Version{}, nil)
 			mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{}, nil)
@@ -54,13 +72,15 @@ func TestUnitFilterOverview(t *testing.T) {
 			So(w.Body.String(), ShouldEqual, "some-bytes")
 		})
 
-		Convey("test sucessful FilterOverviewClearAll", func() {
+		Convey("test successful FilterOverviewClearAll", func() {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
-			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{filter.Dimension{Name: "Day"}, filter.Dimension{Name: "Goods and Services"}}, nil)
+			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
 			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
 			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
 			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services")
 			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services")
+			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography")
+			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography")
 
 			req := httptest.NewRequest("GET", "/filters/12345/dimensions/clear-all", nil)
 			w := httptest.NewRecorder()

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -250,7 +250,15 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
+		selectedValueLabels, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
+		if err != nil {
+			log.Event(ctx, "failed to get options from dataset client for the selected values", log.ERROR, log.Error(err),
+				log.Data{"dimension": name, "dataset_id": datasetID, "edition": edition, "version": version})
+			setStatusCode(req, w, err)
+			return
+		}
+
+		p := mapper.CreateHierarchyPage(req, h, d, fil, selectedValueLabels, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -201,6 +201,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 				h, err = f.HierarchyClient.GetRoot(ctx, fil.InstanceID, name)
 			}
 		}
+
 		if err != nil {
 			log.Event(ctx, "failed to get hierarchy node", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name, "code": code})
 			setStatusCode(req, w, err)
@@ -241,14 +242,6 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		allVals, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 0)
-		if err != nil {
-			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),
-				log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
-			setStatusCode(req, w, err)
-			return
-		}
-
 		dims, err := f.DatasetClient.GetVersionDimensions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version)
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err),
@@ -257,7 +250,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		p := mapper.CreateHierarchyPage(req, h, d, fil, selVals.Items, allVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
+		p := mapper.CreateHierarchyPage(req, h, d, fil, selVals, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -71,9 +71,9 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		allVals, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 0)
+		idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
 		if err != nil {
-			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),
+			log.Event(ctx, "failed to get options from dataset client for the selected values", log.ERROR, log.Error(err),
 				log.Data{"dimension": name, "dataset_id": datasetID, "edition": edition, "version": version})
 			setStatusCode(req, w, err)
 			return
@@ -95,7 +95,7 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selVals.Items, dims.Items, allVals, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.APIRouterVersion, lang)
+		p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, idLabelMap, dims.Items, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.APIRouterVersion, lang)
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -77,7 +77,7 @@ func TestUnitSearch(t *testing.T) {
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, 0).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), nil)
 
@@ -150,7 +150,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, 0).Return(dataset.Options{}, errors.New("get options error"))
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, errors.New("get options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -167,7 +167,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, 0).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, errors.New("search api error"))
 
 			w := callSearch()
@@ -185,7 +185,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, 0).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), errors.New("renderer error"))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -778,7 +778,7 @@ func CreateTimePage(req *http.Request, f filter.Model, d dataset.DatasetDetails,
 }
 
 // CreateHierarchySearchPage forms a search page based on various api response models
-func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst dataset.DatasetDetails, f filter.Model, selVals []filter.DimensionOption, dims []dataset.VersionDimension, allVals dataset.Options, name, curPath, datasetID, releaseDate, referrer, query, apiRouterVersion, lang string) hierarchy.Page {
+func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst dataset.DatasetDetails, f filter.Model, selectedIDLabelMap map[string]string, dims []dataset.VersionDimension, name, curPath, datasetID, releaseDate, referrer, query, apiRouterVersion, lang string) hierarchy.Page {
 	var p hierarchy.Page
 	p.BetaBannerEnabled = true
 
@@ -844,13 +844,11 @@ func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst datas
 	p.Data.AddAllFilters.URL = curPath + "/add-all"
 	p.Data.RemoveAll.URL = curPath + "/remove-all"
 
-	idLabelMap := getIDNameLookup(allVals)
-
-	for _, val := range selVals {
+	for option, label := range selectedIDLabelMap {
 		p.Data.FiltersAdded = append(p.Data.FiltersAdded, hierarchy.Filter{
-			Label:     idLabelMap[val.Option],
-			RemoveURL: fmt.Sprintf("%s/remove/%s", curPath, val.Option),
-			ID:        val.Option,
+			Label:     label,
+			RemoveURL: fmt.Sprintf("%s/remove/%s", curPath, option),
+			ID:        option,
 		})
 	}
 
@@ -859,13 +857,7 @@ func CreateHierarchySearchPage(req *http.Request, items []search.Item, dst datas
 	} else {
 
 		for _, item := range items {
-			var selected bool
-			for _, val := range selVals {
-				if val.Option == item.Code {
-					selected = true
-				}
-			}
-
+			_, selected := selectedIDLabelMap[item.Code]
 			p.Data.FilterList = append(p.Data.FilterList, hierarchy.List{
 				Label:    item.Label,
 				ID:       item.Code,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
 	"github.com/ONSdigital/dp-frontend-models/model"
+	hierarchyModel "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/hierarchy"
 	timeModel "github.com/ONSdigital/dp-frontend-models/model/dataset-filter/time"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	. "github.com/smartystreets/goconvey/convey"
@@ -375,6 +376,80 @@ func TestUnitMapCookiesPreferences(t *testing.T) {
 		So(pageModel.CookiesPolicy.Essential, ShouldEqual, true)
 		So(pageModel.CookiesPolicy.Usage, ShouldEqual, true)
 	})
+}
+
+func TestCreateHierarchyPage(t *testing.T) {
+	var testHierarchyPage hierarchyModel.Page
+	testHierarchyPage.Page = model.Page{
+		Type:      "type",
+		DatasetId: "testDatasetID",
+		HasJSONLD: false,
+		FeatureFlags: model.FeatureFlags{
+			HideCookieBanner: false,
+		},
+		CookiesPolicy: model.CookiesPolicy{
+			Essential: true,
+			Usage:     false,
+		},
+		CookiesPreferencesSet:            true,
+		BetaBannerEnabled:                false,
+		SiteDomain:                       "",
+		SearchDisabled:                   false,
+		URI:                              "",
+		Taxonomy:                         nil,
+		ReleaseDate:                      "",
+		IsInFilterBreadcrumb:             false,
+		Language:                         "en",
+		IncludeAssetsIntegrityAttributes: false,
+		DatasetTitle:                     "datasetTitle",
+		Metadata: model.Metadata{
+			Title:       "Filter Options - MyDimension",
+			Description: "",
+			ServiceName: "",
+			Keywords:    nil,
+		},
+		Breadcrumb: []model.TaxonomyNode{
+			{Title: ""},
+			{Title: ""},
+			{Title: ""},
+			{Title: ""},
+		},
+		PatternLibraryAssetsPath: "",
+	}
+
+	testHierarchyPage.Data = hierarchyModel.Hierarchy{
+		Title: "MyDimension",
+		SaveAndReturn: hierarchyModel.Link{
+			URL:   "filters/12345/dimensions/myDimension/update",
+			Label: "",
+		},
+		Cancel: hierarchyModel.Link{
+			URL:   "/filters/12345/dimensions",
+			Label: "",
+		},
+		FiltersAmount: "",
+		FilterList:    nil,
+		AddAllFilters: hierarchyModel.AddAll{
+			Amount: "0",
+			URL:    "/filters/12345/dimensions/myDimension/add-all",
+		},
+		FiltersAdded: []hierarchyModel.Filter{
+			{
+				Label:     "",
+				RemoveURL: "/filters/12345/dimensions/myDimension/remove/op1",
+				ID:        "op1",
+			},
+			{
+				Label:     "",
+				RemoveURL: "/filters/12345/dimensions/myDimension/remove/op2",
+				ID:        "op2",
+			},
+		},
+		RemoveAll:     hierarchyModel.Link{},
+		DimensionName: "MyDimension",
+		SearchURL:     "/filters/12345/dimensions/myDimension/search",
+	}
+	testHierarchyPage.FilterID = ""
 }
 
 func TestCreateTimePage(t *testing.T) {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -437,14 +437,9 @@ func TestCreateHierarchyPage(t *testing.T) {
 			},
 			FiltersAdded: []hierarchyModel.Filter{
 				{
-					Label:     "",
+					Label:     "This is option 1",
 					RemoveURL: "//remove/op1",
 					ID:        "op1",
-				},
-				{
-					Label:     "",
-					RemoveURL: "//remove/op2",
-					ID:        "op2",
 				},
 			},
 			RemoveAll: hierarchyModel.Link{
@@ -455,16 +450,7 @@ func TestCreateHierarchyPage(t *testing.T) {
 		}
 		testHierarchyPage.FilterID = "12349876"
 
-		testSelectedOptions := filter.DimensionOptions{
-			Items: []filter.DimensionOption{
-				{Option: "op1"},
-				{Option: "op2"},
-			},
-			Count:      2,
-			TotalCount: 2,
-			Limit:      0,
-			Offset:     0,
-		}
+		testSelectedOptions := map[string]string{"op1": "This is option 1"}
 
 		testVersion := dataset.Version{
 			ReleaseDate: "testRelease",


### PR DESCRIPTION
### What

`GetOptions` was being used on the filter overview and hierarchy pages to map labels to the option IDs that had been selected by the user. This was being used to then display in the basket. This method call has since been updated to allow for batching, to ensure that this call doesn't lead to an OOM error when getting the options for very large datasets.

This PR covers just the implementation in the building of the filter overview, hierarchy/hierarchy search pages

Also implemented tests that were not present previously for building hierarchy pages

### How to review

- Check tests pass
- Sense check implementation changes

### Who can review

Ravi and David paired on this exercise, so anyone else