### PR TITLE
Feature/get filter options batches

### DIFF
--- a/handlers/age.go
+++ b/handlers/age.go
@@ -216,7 +216,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
-		selValues, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, dimensionName, 0, 0)
+		selValues, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, dimensionName)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
 )
 
@@ -91,21 +92,51 @@ func (f *Filter) getIDNameLookupFromDatasetAPI(ctx context.Context, userAccessTo
 func (f *Filter) GetDimensionOptionsFromFilterAPI(ctx context.Context, userAccessToken, collectionID, filterID, dimensionName string) (opts filter.DimensionOptions, err error) {
 
 	// initialise an empty options struct
-	opts = filter.DimensionOptions{}
+	opts = filter.DimensionOptions{TotalCount: 1}
 
 	// call filterAPI GetDimensionOptions with pagination until we obtain all values
 	offset := 0
-	totalCount := 1
-	for offset < totalCount {
+	for offset < opts.TotalCount {
 		// get options batch from filter API
 		batchOpts, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, dimensionName, offset, f.BatchSize)
 		if err != nil {
-			return opts, err
+			return filter.DimensionOptions{}, err
 		}
 
 		// (first iteration only) - set totalCount
 		if offset == 0 {
-			totalCount = batchOpts.TotalCount
+			opts.TotalCount = batchOpts.TotalCount
+		}
+
+		// append options for the current batch
+		opts.Items = append(opts.Items, batchOpts.Items...)
+
+		// set offset for the next iteration
+		offset += f.BatchSize
+	}
+
+	// batch processing completed, return all accumulated options
+	opts.Count = len(opts.Items)
+	return opts, nil
+}
+
+// GetDimensionOptionsFromDatasetAPI gets the filter options for a dimension from filter API in batches
+func (f *Filter) GetDimensionOptionsFromDatasetAPI(ctx context.Context, userAccessToken, collectionID, datasetID, edition, version, dimensionName string) (opts dataset.Options, err error) {
+
+	// initialise an empty options struct
+	opts = dataset.Options{TotalCount: 1}
+
+	// call datasetAPI GetOptions with pagination until we obtain all values
+	offset := 0
+	for offset < opts.TotalCount {
+		// get batch
+		batchOpts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, offset, f.BatchSize)
+		if err != nil {
+			return dataset.Options{}, err
+		}
+
+		// (first iteration only) - set totalCount
+		if offset == 0 {
 			opts.TotalCount = batchOpts.TotalCount
 		}
 

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -122,7 +122,7 @@ func (f *Filter) GetSelectedDimensionOptionsJSON() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		opts, err := f.FilterClient.GetDimensionOptions(req.Context(), userAccessToken, "", collectionID, filterID, name, 0, 0)
+		opts, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to get dimension options", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
@@ -208,7 +208,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			return
 		}
 
-		selectedValues, err := f.FilterClient.GetDimensionOptions(req.Context(), userAccessToken, "", collectionID, filterID, name, 0, 0)
+		selectedValues, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
@@ -542,8 +542,8 @@ func (f *Filter) AddList() http.HandlerFunc {
 			return
 		}
 
-		// TODO concurrently remove any fields that have been deselected
-		opts, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, name, 0, 0)
+		// TODO remove any fields that have been deselected via patch call (call patch for each batch of options)
+		opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const maxNumOptionsOnPage = 20
+
 type labelID struct {
 	Label string `json:"label"`
 	ID    string `json:"id"`
@@ -244,7 +246,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			return
 		}
 
-		allValues, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 0)
+		allValues, err := f.GetDimensionOptionsFromDatasetAPI(req.Context(), userAccessToken, collectionID, datasetID, edition, version, name)
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err), log.Data{"dimension": name, "dataset_id": datasetID, "edition": edition, "version": version})
 			setStatusCode(req, w, err)
@@ -259,7 +261,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			return
 		}
 
-		if isHierarchy && len(allValues.Items) > 20 {
+		if isHierarchy && allValues.TotalCount > maxNumOptionsOnPage {
 			f.Hierarchy().ServeHTTP(w, req)
 			return
 		}

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -65,7 +65,7 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 		// get selected options from filter API for each dimension and then get the labels from dataset API for each option
 		var dimensions FilterModelDimensions
 		for _, dim := range dims {
-			selVals, err := f.FilterClient.GetDimensionOptions(req.Context(), userAccessToken, "", collectionID, filterID, dim.Name, 0, 0)
+			selVals, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, dim.Name)
 			if err != nil {
 				log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -43,9 +43,9 @@ func TestUnitFilterOverview(t *testing.T) {
 		Convey("test FilterOverview can successfully load a page", func() {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
 			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, 0).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", 0, 0).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, 0).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -208,7 +208,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		selVals, err := f.FilterClient.GetDimensionOptions(req.Context(), userAccessToken, "", collectionID, filterID, name, 0, 0)
+		selVals, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -250,7 +250,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		selectedValueLabels, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
+		selValsLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client for the selected values", log.ERROR, log.Error(err),
 				log.Data{"dimension": name, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -258,7 +258,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		p := mapper.CreateHierarchyPage(req, h, d, fil, selectedValueLabels, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
+		p := mapper.CreateHierarchyPage(req, h, d, fil, selValsLabelMap, dims, name, req.URL.Path, datasetID, ver.ReleaseDate, f.APIRouterVersion, lang)
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -123,7 +123,7 @@ func TestHierarchy(t *testing.T) {
 			testTemplate := []byte{1, 2, 3, 4, 5}
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, 0).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
@@ -140,7 +140,7 @@ func TestHierarchy(t *testing.T) {
 			testTemplate := []byte{1, 2, 3, 4, 5}
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, 0).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
@@ -156,7 +156,7 @@ func TestHierarchy(t *testing.T) {
 		Convey("Hierarchy called for the root node calls the expected methods. If dataset GetOption fails, an InternalServerError status code is returned", func() {
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, 0).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -71,7 +71,7 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
+		selValsLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, name, selVals)
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client for the selected values", log.ERROR, log.Error(err),
 				log.Data{"dimension": name, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -95,7 +95,7 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, idLabelMap, dims.Items, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.APIRouterVersion, lang)
+		p := mapper.CreateHierarchySearchPage(req, searchRes.Items, d, fil, selValsLabelMap, dims.Items, name, req.URL.Path, datasetID, ver.ReleaseDate, req.Referer(), req.URL.Query().Get("q"), f.APIRouterVersion, lang)
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -37,7 +37,7 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		selVals, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, name, 0, 0)
+		selVals, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
@@ -192,7 +192,7 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 		}
 
 		// get all available dimension options from filter API
-		opts, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, name, 0, 0)
+		opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, name)
 		if err != nil {
 			log.Event(ctx, "failed to retrieve dimension options", log.WARN, log.Error(err))
 			setStatusCode(req, w, err)

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -73,7 +73,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
@@ -102,7 +102,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, errors.New("get dimensions options error"))
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, errors.New("get dimensions options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -116,7 +116,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, errors.New("dataset get error"))
 
 			w := callSearch()
@@ -131,7 +131,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, errors.New("get version error"))
 
@@ -147,7 +147,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, errors.New("get options error"))
@@ -164,7 +164,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
@@ -182,7 +182,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
@@ -203,7 +203,7 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -322,7 +322,7 @@ func TestSearchUpdate(t *testing.T) {
 			expectedRemoveOptions := []string{"clothing-4"}
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(searchModel, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filterOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filterOptions, nil)
 			mfc.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
 				ItemsEq(expectedAddOptions), ItemsEq(expectedRemoveOptions), batchSize).Return(nil)
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
@@ -333,7 +333,7 @@ func TestSearchUpdate(t *testing.T) {
 		Convey("When GetDimensionOptions fails with a generic error, then the execution is aborted and an Internal Server Error is returned.", func() {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(&search.Model{}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, 0).Return(filter.DimensionOptions{}, errors.New("Error getting dimention options"))
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, errors.New("Error getting dimention options"))
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -242,7 +242,7 @@ func (f *Filter) Time() http.HandlerFunc {
 			return
 		}
 
-		selValues, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, dimensionName, 0, 0)
+		selValues, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, dimensionName)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)

--- a/handlers/update-version.go
+++ b/handlers/update-version.go
@@ -71,7 +71,7 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 				return
 			}
 
-			dimValues, err := f.FilterClient.GetDimensionOptions(req.Context(), userAccessToken, "", collectionID, filterID, dim.Name, 0, 0)
+			dimValues, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, dim.Name)
 			if err != nil {
 				log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)

--- a/handlers/update-version_test.go
+++ b/handlers/update-version_test.go
@@ -51,7 +51,7 @@ func TestUseLatest(t *testing.T) {
 		mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{Links: mockEditionLinks}, nil)
 		mockFilterClient.EXPECT().CreateBlueprint(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "2", []string{}).Return(mockNewFilterID, nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day").Return(nil)
-		mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, 0).Return(mockDimensionOption, nil)
+		mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, batchSize).Return(mockDimensionOption, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day", []string{mockDimensionOption.Items[0].Option}).Return(nil)
 
 		mockRenderer := NewMockRenderer(mockCtrl)


### PR DESCRIPTION
### What

- Implemented batch paginated calls for `filter.GetDimensionOptions` in common.go
- Replaced all calls to filter.GetDimesionOptions with 
- Unit tested the batch paginated calls
- Updated existing unit tests accordingly

- Implemented batch paginated calls for `dataset.GetOptions` in common.go
- Use batch paginated calls to GetOptions in dimensions.go

### How to review

- Make sure code changes make sense
- Make sure unit tests are successful

### Who can review

Anyone