### PR TITLE
Get Options by IDs from dataset API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,8 @@ func Get() (cfg *Config, err error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		BatchSizeLimit:             1000,
+		BatchSizeLimit:             1000, // maximum limit value to get items from APIs in a single call
+		MaxDatasetOptions:          200,  // maximum number of IDs that will be requested to dataset API in a single call as query parmeters
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
 	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
 	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
+	MaxDatasetOptions          int           `envconfig:"MAX_DATASET_OPTIONS"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-dataset-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.31.2
+	github.com/ONSdigital/dp-api-clients-go v1.32.0
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-dataset-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.31.0
+	github.com/ONSdigital/dp-api-clients-go v1.31.2
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.29.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.31.0 h1:+/GXXtQAPbfK3gORTKzsSkQTtVzIl4tqPR7AZAA9NFU=
-github.com/ONSdigital/dp-api-clients-go v1.31.0/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.31.2 h1:2ZutIrkPeUv6BmmBlVj0sjfr/kTavVAk9qIOpNEt/uQ=
+github.com/ONSdigital/dp-api-clients-go v1.31.2/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0 h1:jMM5drrwcOK5H0DTL8JpLOZm2rw+VJrz+vI9h2GQ8nQ=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.29.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.31.2 h1:2ZutIrkPeUv6BmmBlVj0sjfr/kTavVAk9qIOpNEt/uQ=
-github.com/ONSdigital/dp-api-clients-go v1.31.2/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.32.0 h1:yHIBcpTQf4MasDN53tXuwwWVj5PRZ9KLF0RGEejOEMM=
+github.com/ONSdigital/dp-api-clients-go v1.32.0/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0 h1:jMM5drrwcOK5H0DTL8JpLOZm2rw+VJrz+vI9h2GQ8nQ=

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -203,6 +203,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
+		// count number of options for the dimension in dataset API
 		opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, dataset.QueryParams{Offset: 0, Limit: 1})
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -204,7 +204,8 @@ func (f *Filter) Age() http.HandlerFunc {
 		}
 
 		// count number of options for the dimension in dataset API
-		opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, dataset.QueryParams{Offset: 0, Limit: 1})
+		opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName,
+			dataset.QueryParams{Offset: 0, Limit: 1})
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),
 				log.Data{"dimension": dimensionName, "dataset_id": datasetID, "edition": edition, "version": version})

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 	"github.com/ONSdigital/log.go/log"
 
@@ -189,7 +190,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
-		dataset, err := f.DatasetClient.Get(ctx, userAccessToken, "", collectionID, datasetID)
+		datasetDetails, err := f.DatasetClient.Get(ctx, userAccessToken, "", collectionID, datasetID)
 		if err != nil {
 			log.Event(ctx, "failed to get dataset", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID})
 			setStatusCode(req, w, err)
@@ -202,7 +203,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
-		allValues, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, 0, 0)
+		allValues, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, dataset.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),
 				log.Data{"dimension": dimensionName, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -230,7 +231,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
-		p, err := mapper.CreateAgePage(req, fj, dataset, ver, allValues, selValues.Items, dims, datasetID, f.APIRouterVersion, lang)
+		p, err := mapper.CreateAgePage(req, fj, datasetDetails, ver, allValues, selValues.Items, dims, datasetID, f.APIRouterVersion, lang)
 		if err != nil {
 			log.Event(ctx, "failed to map data to page", log.ERROR, log.Error(err),
 				log.Data{"filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})

--- a/handlers/age_test.go
+++ b/handlers/age_test.go
@@ -86,7 +86,7 @@ func TestUpdateAge(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age", 0, 0).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age", dataset.QueryParams{}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age", filterOptions).Return(nil)
 		formData := "all-ages-option=total&age-selection=range&youngest-age=0&oldest-age=90%2B&youngest=18&oldest=24&save-and-return=Save+and+return"
 		w := callAgeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/age_test.go
+++ b/handlers/age_test.go
@@ -94,7 +94,7 @@ func TestUpdateAge(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age", dataset.QueryParams{}).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age", filterOptions).Return(nil)
 		formData := "all-ages-option=total&age-selection=range&youngest-age=0&oldest-age=90%2B&youngest=18&oldest=24&save-and-return=Save+and+return"
 		w := callAgeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/age_test.go
+++ b/handlers/age_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
@@ -22,6 +23,13 @@ func TestUpdateAge(t *testing.T) {
 	const mockFilterID = ""
 	const batchSize = 100
 
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockServiceAuthToken,
+		DownloadServiceURL:   "",
+		EnableDatasetPreview: false,
+		BatchSizeLimit:       batchSize,
+	}
+
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := gomock.Any()
@@ -34,7 +42,7 @@ func TestUpdateAge(t *testing.T) {
 		req.Header.Add(dprequest.FlorenceHeaderKey, mockUserAuthToken)
 		req.Header.Add(dprequest.CollectionIDHeaderKey, mockCollectionID)
 		w := httptest.NewRecorder()
-		f := NewFilter(nil, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+		f := NewFilter(nil, mockFilterClient, mockDatasetClient, nil, nil, nil, "/v1", cfg)
 		f.UpdateAge().ServeHTTP(w, req)
 		return w
 	}

--- a/handlers/age_test.go
+++ b/handlers/age_test.go
@@ -94,7 +94,8 @@ func TestUpdateAge(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "mid-year-pop-est", "mid-2019-april-2020-geography", "1", "age",
+			dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "age", filterOptions).Return(nil)
 		formData := "all-ages-option=total&age-selection=range&youngest-age=0&oldest-age=90%2B&youngest=18&oldest=24&save-and-return=Save+and+return"
 		w := callAgeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -43,7 +43,7 @@ type DatasetClient interface {
 	Get(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m dataset.DatasetDetails, err error)
 	GetVersion(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string) (m dataset.Version, err error)
 	GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.VersionDimensions, err error)
-	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension string, offset, limit int) (m dataset.Options, err error)
+	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension string, q dataset.QueryParams) (m dataset.Options, err error)
 	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version string) (m dataset.Metadata, err error)
 	GetEdition(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition string) (m dataset.Edition, err error)
 }

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -21,8 +21,8 @@ type ClientError interface {
 // FilterClient contains the methods expected for a filter client
 type FilterClient interface {
 	Checker(ctx context.Context, check *health.CheckState) error
-	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string) (dims []filter.Dimension, err error)
-	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) (fdv filter.DimensionOptions, err error)
+	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (dims filter.Dimensions, err error)
+	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (fdv filter.DimensionOptions, err error)
 	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, err error)
 	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (f filter.Model, err error)
 	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, err error)

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -110,7 +110,7 @@ func (f *Filter) GetDimensionOptionsFromFilterAPI(ctx context.Context, userAcces
 		return nil
 	}
 
-	// call filter API GetOptions in bathes and aggregate the responses
+	// call filter API GetOptions in batches and aggregate the responses
 	if err := f.BatchProcessDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, dimensionName, processBatch); err != nil {
 		return filter.DimensionOptions{}, err
 	}
@@ -164,7 +164,7 @@ func (f *Filter) GetDimensionOptionsFromDatasetAPI(ctx context.Context, userAcce
 		return nil
 	}
 
-	// call dataset API GetOptions in bathes and aggregate the responses
+	// call dataset API GetOptions in batches and aggregate the responses
 	if err := f.BatchProcessDimensionOptionsFromDatasetAPI(ctx, userAccessToken, collectionID, datasetID, edition, version, dimensionName, processBatch); err != nil {
 		return dataset.Options{}, err
 	}

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -57,7 +57,7 @@ func (f *Filter) getIDNameLookupFromDatasetAPI(ctx context.Context, userAccessTo
 	foundCount := 0
 	for offset < totalCount {
 		// get options batch from dataset API
-		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, offset, f.BatchSize)
+		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: offset, Limit: f.BatchSize})
 		if err != nil {
 			return idLabelMap, err
 		}
@@ -130,7 +130,7 @@ func (f *Filter) GetDimensionOptionsFromDatasetAPI(ctx context.Context, userAcce
 	offset := 0
 	for offset < opts.TotalCount {
 		// get batch
-		batchOpts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, offset, f.BatchSize)
+		batchOpts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, dataset.QueryParams{Offset: offset, Limit: f.BatchSize})
 		if err != nil {
 			return dataset.Options{}, err
 		}

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -108,7 +108,7 @@ func (f *Filter) GetDimensionOptionsFromFilterAPI(ctx context.Context, userAcces
 	offset := 0
 	for offset < opts.TotalCount {
 		// get options batch from filter API
-		batchOpts, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, dimensionName, offset, f.BatchSize)
+		batchOpts, err := f.FilterClient.GetDimensionOptions(ctx, userAccessToken, "", collectionID, filterID, dimensionName, filter.QueryParams{Offset: offset, Limit: f.BatchSize})
 		if err != nil {
 			return filter.DimensionOptions{}, err
 		}

--- a/handlers/common_test.go
+++ b/handlers/common_test.go
@@ -144,7 +144,8 @@ func TestGetDimensionOptionsFromFilterAPI(t *testing.T) {
 			batchSize := 100
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, mfc, nil, nil, nil, nil, "/v1", cfg)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filterOptions(0, batchSize), nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filterOptions(0, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, mockUserAuthToken, mockCollectionID, filterID, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, filterOptions(0, 0))
@@ -154,8 +155,10 @@ func TestGetDimensionOptionsFromFilterAPI(t *testing.T) {
 			batchSize := 3
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, mfc, nil, nil, nil, nil, "/v1", cfg)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filterOptions(0, batchSize), nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, batchSize, batchSize).Return(filterOptions(batchSize, batchSize), nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filterOptions(0, batchSize), nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: batchSize, Limit: batchSize}).Return(filterOptions(batchSize, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, mockUserAuthToken, mockCollectionID, filterID, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, filterOptions(0, 0))
@@ -166,7 +169,8 @@ func TestGetDimensionOptionsFromFilterAPI(t *testing.T) {
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, mfc, nil, nil, nil, nil, "/v1", cfg)
 			expectedErr := errors.New("error getting options from Filter API")
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, expectedErr)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, expectedErr)
 			opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, mockUserAuthToken, mockCollectionID, filterID, name)
 			So(err, ShouldResemble, expectedErr)
 			So(opts, ShouldResemble, filter.DimensionOptions{})
@@ -202,7 +206,8 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 			batchSize := 100
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, "/v1", cfg)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, datasetOptions(0, 0))
@@ -212,8 +217,10 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 			batchSize := 3
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, "/v1", cfg)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: batchSize, Limit: batchSize}).Return(datasetOptions(batchSize, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{Offset: batchSize, Limit: batchSize}).Return(datasetOptions(batchSize, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, datasetOptions(0, 0))
@@ -224,7 +231,8 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 			cfg.BatchSizeLimit = batchSize
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, "/v1", cfg)
 			expectedErr := errors.New("error getting options from Dataset API")
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, expectedErr)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, expectedErr)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldResemble, expectedErr)
 			So(opts, ShouldResemble, dataset.Options{})

--- a/handlers/common_test.go
+++ b/handlers/common_test.go
@@ -39,7 +39,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 					{Option: "op2"},
 				},
 			}
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldBeNil)
 			So(idLabelMap, ShouldResemble, map[string]string{
@@ -58,8 +58,8 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 					{Option: "op5"}, // belongs to second batch
 				},
 			}
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, batchSize, batchSize).Return(datasetOptions(batchSize, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: batchSize, Limit: batchSize}).Return(datasetOptions(batchSize, batchSize), nil)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldBeNil)
 			So(idLabelMap, ShouldResemble, map[string]string{
@@ -78,7 +78,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 					{Option: "op2"}, // belongs to first batch
 				},
 			}
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldBeNil)
 			So(idLabelMap, ShouldResemble, map[string]string{
@@ -96,7 +96,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 					{Option: "inexistent"},
 				},
 			}
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
 			expectedErr := errors.New("could not find all required filter options in dataset API")
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldResemble, expectedErr)
@@ -113,7 +113,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 				Items: []filter.DimensionOption{{Option: "op1"}},
 			}
 			expectedErr := errors.New("error getting options from Dataset API")
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, expectedErr)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, expectedErr)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldResemble, expectedErr)
 			So(idLabelMap, ShouldResemble, map[string]string{"op1": ""})
@@ -188,7 +188,7 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 		Convey("given that the number of dataset options is smaller than a batch, then all options are returned after a single batch getOptions call", func() {
 			batchSize := 100
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, datasetOptions(0, 0))
@@ -197,8 +197,8 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 		Convey("given that the number of dataset options is greater than a batch, then all options are returned after multiple batch getOptions calls", func() {
 			batchSize := 3
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(datasetOptions(0, batchSize), nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, batchSize, batchSize).Return(datasetOptions(batchSize, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions(0, batchSize), nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: batchSize, Limit: batchSize}).Return(datasetOptions(batchSize, batchSize), nil)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, datasetOptions(0, 0))
@@ -208,7 +208,7 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 			batchSize := 2
 			f := NewFilter(nil, nil, mdc, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
 			expectedErr := errors.New("error getting options from Dataset API")
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, expectedErr)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, expectedErr)
 			opts, err := f.GetDimensionOptionsFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name)
 			So(err, ShouldResemble, expectedErr)
 			So(opts, ShouldResemble, dataset.Options{})

--- a/handlers/common_test.go
+++ b/handlers/common_test.go
@@ -48,7 +48,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 				},
 			}
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
-				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(datasetOptionsFrmIDs([]string{"op1", "op2"}), nil)
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(datasetOptionsFromIDs([]string{"op1", "op2"}), nil)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldBeNil)
 			So(idLabelMap, ShouldResemble, map[string]string{
@@ -69,9 +69,9 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 				},
 			}
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
-				dataset.QueryParams{IDs: []string{"op1", "op4"}}).Return(datasetOptionsFrmIDs([]string{"op1", "op4"}), nil)
+				dataset.QueryParams{IDs: []string{"op1", "op4"}}).Return(datasetOptionsFromIDs([]string{"op1", "op4"}), nil)
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
-				dataset.QueryParams{IDs: []string{"op5"}}).Return(datasetOptionsFrmIDs([]string{"op5"}), nil)
+				dataset.QueryParams{IDs: []string{"op5"}}).Return(datasetOptionsFromIDs([]string{"op5"}), nil)
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldBeNil)
 			So(idLabelMap, ShouldResemble, map[string]string{
@@ -92,7 +92,7 @@ func TestGetIDNameLookupFromDatasetAPI(t *testing.T) {
 				},
 			}
 			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
-				dataset.QueryParams{IDs: []string{"op1", "inexistent"}}).Return(datasetOptionsFrmIDs([]string{"op1"}), nil)
+				dataset.QueryParams{IDs: []string{"op1", "inexistent"}}).Return(datasetOptionsFromIDs([]string{"op1"}), nil)
 			expectedErr := errors.New("could not find all required filter options in dataset API")
 			idLabelMap, err := f.getIDNameLookupFromDatasetAPI(ctx, mockUserAuthToken, mockCollectionID, datasetID, edition, version, name, filterOptions)
 			So(err, ShouldResemble, expectedErr)
@@ -241,8 +241,8 @@ func TestGetDimensionOptionsFromDataseAPI(t *testing.T) {
 	})
 }
 
-// datasetOptionsFrmIDs returns a mocked dataset.Options struct according to the provided list of IDs
-func datasetOptionsFrmIDs(ids []string) dataset.Options {
+// datasetOptionsFromIDs returns a mocked dataset.Options struct according to the provided list of IDs
+func datasetOptionsFromIDs(ids []string) dataset.Options {
 	items := []dataset.Option{}
 	for _, id := range ids {
 		items = append(items, dataset.Option{

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -104,7 +104,7 @@ func (f *Filter) getIDNameMap(ctx context.Context, userAccessToken, collectionID
 	datasetID, edition, version, err := helpers.ExtractDatasetInfoFromPath(ctx, versionURL)
 
 	idNameMap := make(map[string]string)
-	opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension, 0, 0)
+	opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension, dataset.QueryParams{})
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			return
 		}
 
-		dataset, err := f.DatasetClient.Get(req.Context(), userAccessToken, "", collectionID, datasetID)
+		datasetDetails, err := f.DatasetClient.Get(req.Context(), userAccessToken, "", collectionID, datasetID)
 		if err != nil {
 			log.Event(ctx, "failed to get dataset", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID})
 			setStatusCode(req, w, err)
@@ -248,7 +248,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 		}
 
 		// count number of options in dataset API
-		opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 1)
+		opts, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: 1})
 		if err != nil {
 			setStatusCode(req, w, err)
 			return
@@ -285,7 +285,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			allValues = sortedTime(ctx, allValues)
 		}
 
-		f.listSelector(w, req, name, selectedValues.Items, allValues, fj, dataset, dims, datasetID, ver.ReleaseDate, lang)
+		f.listSelector(w, req, name, selectedValues.Items, allValues, fj, datasetDetails, dims, datasetID, ver.ReleaseDate, lang)
 	})
 
 }
@@ -503,7 +503,7 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL, u
 		return
 	}
 
-	vals, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 0)
+	vals, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, name, dataset.QueryParams{})
 	if err != nil {
 		log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
 		setStatusCode(req, w, err)
@@ -604,7 +604,7 @@ func (f *Filter) getDimensionValues(ctx context.Context, userAccessToken, collec
 		return
 	}
 
-	vals, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, 0, 0)
+	vals, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, name, dataset.QueryParams{})
 	if err != nil {
 		return
 	}

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -526,7 +526,7 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL, u
 	http.Redirect(w, req, redirectURL, 302)
 }
 
-// AddList adds a list of values
+// AddList sets a list of values, removing any existing value.
 func (f *Filter) AddList() http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
 		vars := mux.Vars(req)
@@ -552,22 +552,6 @@ func (f *Filter) AddList() http.HandlerFunc {
 			redirectURL = fmt.Sprintf("/filters/%s/dimensions/%s/remove-all", filterID, name)
 			http.Redirect(w, req, redirectURL, 302)
 			return
-		}
-
-		// TODO remove any fields that have been deselected via patch call (call patch for each batch of options)
-		opts, err := f.GetDimensionOptionsFromFilterAPI(ctx, userAccessToken, collectionID, filterID, name)
-		if err != nil {
-			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
-			setStatusCode(req, w, err)
-			return
-		}
-
-		for _, opt := range opts.Items {
-			if _, ok := req.Form[opt.Option]; !ok {
-				if err := f.FilterClient.RemoveDimensionValue(ctx, userAccessToken, "", collectionID, filterID, name, opt.Option); err != nil {
-					log.Event(ctx, "failed to remove dimension values", log.WARN, log.Error(err))
-				}
-			}
 		}
 
 		var options []string

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -26,7 +26,7 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID)
+		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, filter.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -64,7 +64,7 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 
 		// get selected options from filter API for each dimension and then get the labels from dataset API for each option
 		var dimensions FilterModelDimensions
-		for _, dim := range dims {
+		for _, dim := range dims.Items {
 			selVals, err := f.GetDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, dim.Name)
 			if err != nil {
 				log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
@@ -148,13 +148,13 @@ func (f *Filter) FilterOverviewClearAll() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID)
+		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, filter.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err))
 			return
 		}
 
-		for _, dim := range dims {
+		for _, dim := range dims.Items {
 			if err := f.FilterClient.RemoveDimension(req.Context(), userAccessToken, "", collectionID, filterID, dim.Name); err != nil {
 				log.Event(ctx, "failed to remove dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -65,17 +65,25 @@ func TestUnitFilterOverview(t *testing.T) {
 		Convey("test FilterOverview can successfully load a page, with expected calls", func() {
 			// expected calls to filter api: get dimension and get options for each dimension. Get job state.
 			mockFilterClient := NewMockFilterClient(mockCtrl)
-			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, batchSize).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", 0, batchSize).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, batchSize).Return(filterGeographyOptions, nil)
+			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID,
+				filter.QueryParams{}).Return(
+				filter.Dimensions{
+					Items: []filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}},
+				}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day",
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services",
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography",
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filterGeographyOptions, nil)
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
 
 			// expected calls to dataset api: get options only for options that were found in filter api. Get, GetVersion and GetEdition
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{
 				Items: []dataset.VersionDimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and services"}, {Name: "unused"}}}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", dataset.QueryParams{IDs: []string{"geoUK"}}).Return(datasetGeographyOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography",
+				dataset.QueryParams{IDs: []string{"geoUK"}}).Return(datasetGeographyOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}}, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Version{}, nil)
 			mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{}, nil)
@@ -98,7 +106,11 @@ func TestUnitFilterOverview(t *testing.T) {
 
 		Convey("test successful FilterOverviewClearAll", func() {
 			mockFilterClient := NewMockFilterClient(mockCtrl)
-			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
+			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID,
+				filter.QueryParams{}).Return(
+				filter.Dimensions{
+					Items: []filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}},
+				}, nil)
 			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
 			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
 			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services")

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 
@@ -22,40 +23,63 @@ func TestUnitFilterOverview(t *testing.T) {
 	filterID := "12345"
 	batchSize := 100
 
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockServiceAuthToken,
+		DownloadServiceURL:   "",
+		BatchSizeLimit:       batchSize,
+		MaxDatasetOptions:    3,
+		EnableDatasetPreview: false,
+	}
+
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	Convey("test FilterOverview", t, func() {
+
+		filterGeographyOptions := filter.DimensionOptions{
+			Items: []filter.DimensionOption{
+				{
+					Option: "geoUK",
+				},
+			},
+			Count:      1,
+			TotalCount: 1,
+			Offset:     0,
+			Limit:      0,
+		}
 
 		datasetGeographyOptions := dataset.Options{
 			Items: []dataset.Option{
 				{
 					DimensionID: "geography",
 					Label:       "UK",
+					Option:      "geoUK",
 				},
 			},
 			Count:      1,
 			TotalCount: 1,
 			Offset:     0,
-			Limit:      batchSize,
+			Limit:      0,
 		}
 
-		Convey("test FilterOverview can successfully load a page", func() {
+		Convey("test FilterOverview can successfully load a page, with expected calls", func() {
+			// expected calls to filter api: get dimension and get options for each dimension. Get job state.
 			mockFilterClient := NewMockFilterClient(mockCtrl)
 			mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", 0, batchSize).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", 0, batchSize).Return(filterGeographyOptions, nil)
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
+
+			// expected calls to dataset api: get options only for options that were found in filter api. Get, GetVersion and GetEdition
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{
 				Items: []dataset.VersionDimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and services"}, {Name: "unused"}}}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetGeographyOptions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Day", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Goods and Services", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", dataset.QueryParams{IDs: []string{"geoUK"}}).Return(datasetGeographyOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}}, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Version{}, nil)
 			mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{}, nil)
+
 			mockRenderer := NewMockRenderer(mockCtrl)
 			mockRenderer.EXPECT().Do("dataset-filter/filter-overview", gomock.Any()).Return([]byte("some-bytes"), nil)
 
@@ -63,7 +87,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, "/v1", cfg)
 			router.Path("/filters/{filterID}/dimensions").HandlerFunc(f.FilterOverview())
 
 			router.ServeHTTP(w, req)
@@ -86,7 +110,7 @@ func TestUnitFilterOverview(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+			f := NewFilter(nil, mockFilterClient, nil, nil, nil, nil, "/v1", cfg)
 			router.Path("/filters/{filterID}/dimensions/clear-all").HandlerFunc(f.FilterOverviewClearAll())
 
 			router.ServeHTTP(w, req)

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -50,9 +50,9 @@ func TestUnitFilterOverview(t *testing.T) {
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.VersionDimensions{
 				Items: []dataset.VersionDimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and services"}, {Name: "unused"}}}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", 0, batchSize).Return(datasetGeographyOptions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Day", 0, batchSize).Return(dataset.Options{}, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Goods and Services", 0, batchSize).Return(dataset.Options{}, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "geography", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetGeographyOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Day", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1", "Goods and Services", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}}, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "1").Return(dataset.Version{}, nil)
 			mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{}, nil)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/log.go/log"
 )
 
@@ -20,12 +21,12 @@ type Filter struct {
 	EnableDatasetPreview bool
 	APIRouterVersion     string
 	BatchSize            int
+	maxDatasetOptions    int
 }
 
 // NewFilter creates a new instance of Filter
 func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient,
-	sc SearchClient, val Validator, searchAPIAuthToken, downloadServiceURL, apiRouterVersion string, enableDatasetPreview bool, batchSize int) *Filter {
-
+	sc SearchClient, val Validator, apiRouterVersion string, cfg *config.Config) *Filter {
 	return &Filter{
 		Renderer:             r,
 		FilterClient:         fc,
@@ -33,11 +34,12 @@ func NewFilter(r Renderer, fc FilterClient, dc DatasetClient, hc HierarchyClient
 		HierarchyClient:      hc,
 		SearchClient:         sc,
 		val:                  val,
-		downloadServiceURL:   downloadServiceURL,
-		EnableDatasetPreview: enableDatasetPreview,
-		SearchAPIAuthToken:   searchAPIAuthToken,
 		APIRouterVersion:     apiRouterVersion,
-		BatchSize:            batchSize,
+		downloadServiceURL:   cfg.DownloadServiceURL,
+		EnableDatasetPreview: cfg.EnableDatasetPreview,
+		SearchAPIAuthToken:   cfg.SearchAPIAuthToken,
+		BatchSize:            cfg.BatchSizeLimit,
+		maxDatasetOptions:    cfg.MaxDatasetOptions,
 	}
 }
 

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -176,6 +176,7 @@ func (f *Filter) removeAllHierarchyLevel(w http.ResponseWriter, req *http.Reques
 	http.Redirect(w, req, redirectURI, 302)
 }
 
+// Hierarchy controls the creation of a hierarchy page
 func (f *Filter) Hierarchy() http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
 		vars := mux.Vars(req)

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -127,7 +127,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, 0, batchSize).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
@@ -144,7 +144,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, 0, batchSize).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s", filterID, dimensionName, mockCode))
@@ -160,7 +160,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, 0, batchSize).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
 

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -132,11 +132,13 @@ func TestHierarchy(t *testing.T) {
 			testTemplate := []byte{1, 2, 3, 4, 5}
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
@@ -149,11 +151,13 @@ func TestHierarchy(t *testing.T) {
 			testTemplate := []byte{1, 2, 3, 4, 5}
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s", filterID, dimensionName, mockCode))
@@ -165,11 +169,13 @@ func TestHierarchy(t *testing.T) {
 		Convey("Hierarchy called for the root node calls the expected methods. If dataset GetOption fails, an InternalServerError status code is returned", func() {
 			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName, 0, batchSize).Return(testSelectedOptions, nil)
+			mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
 

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
 	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
@@ -50,6 +51,14 @@ func TestHierarchy(t *testing.T) {
 				HRef: fmt.Sprintf("http://localhost:1234/v1/datasets/%s/editions/%s/versions/%s", mockDatasetID, mockEdition, mockVersion),
 			},
 		},
+	}
+
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockSearchAPIAuthToken,
+		DownloadServiceURL:   "",
+		BatchSizeLimit:       batchSize,
+		MaxDatasetOptions:    10,
+		EnableDatasetPreview: false,
 	}
 
 	Convey("Given a set of mocked clients and models", t, func() {
@@ -112,7 +121,7 @@ func TestHierarchy(t *testing.T) {
 
 			router := mux.NewRouter()
 			w := httptest.NewRecorder()
-			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", "/v1", false, batchSize)
+			f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, mockHierarchyClient, nil, nil, "/v1", cfg)
 			router.Path("/filters/{filterID}/dimensions/{name}").HandlerFunc(f.Hierarchy())
 			router.Path("/filters/{filterID}/dimensions/{name}/{code}").HandlerFunc(f.Hierarchy())
 			router.ServeHTTP(w, req)
@@ -127,7 +136,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
@@ -144,7 +153,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(testDatasetOptions, nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			mockRenderer.EXPECT().Do(gomock.Eq("dataset-filter/hierarchy"), gomock.Any()).Return(testTemplate, nil)
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s", filterID, dimensionName, mockCode))
@@ -160,7 +169,7 @@ func TestHierarchy(t *testing.T) {
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
+			mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion, dimensionName, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(dataset.Options{}, errors.New("error in DatasetAPI"))
 
 			w := callHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimensionName))
 
@@ -190,6 +199,13 @@ func TestHierarchyUpdate(t *testing.T) {
 	filterModel := filter.Model{
 		InstanceID: testInstanceID,
 		FilterID:   filterID,
+	}
+
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockSearchAPIAuthToken,
+		DownloadServiceURL:   "",
+		BatchSizeLimit:       batchSize,
+		EnableDatasetPreview: false,
 	}
 
 	Convey("Given a set of mocked clients", t, func() {
@@ -226,7 +242,7 @@ func TestHierarchyUpdate(t *testing.T) {
 
 			router := mux.NewRouter()
 			w := httptest.NewRecorder()
-			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, mockSearchAPIAuthToken, "", "/v1", false, batchSize)
+			f := NewFilter(nil, mockFilterClient, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
 			router.Path("/filters/{filterID}/dimensions/{name}/update").HandlerFunc(f.HierarchyUpdate())
 			router.Path("/filters/{filterID}/dimensions/{name}/{code}/update").HandlerFunc(f.HierarchyUpdate())
 			router.ServeHTTP(w, req)

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -390,18 +390,18 @@ func (mr *MockDatasetClientMockRecorder) GetVersionDimensions(ctx, userAuthToken
 }
 
 // GetOptions mocks base method
-func (m *MockDatasetClient) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension string, offset, limit int) (dataset.Options, error) {
+func (m *MockDatasetClient) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension string, q dataset.QueryParams) (dataset.Options, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOptions", ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, offset, limit)
+	ret := m.ctrl.Call(m, "GetOptions", ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, q)
 	ret0, _ := ret[0].(dataset.Options)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOptions indicates an expected call of GetOptions
-func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, offset, limit interface{}) *gomock.Call {
+func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, offset, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version, dimension, q)
 }
 
 // GetVersionMetadata mocks base method

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -104,33 +104,33 @@ func (mr *MockFilterClientMockRecorder) Checker(ctx, check interface{}) *gomock.
 }
 
 // GetDimensions mocks base method
-func (m *MockFilterClient) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string) ([]filter.Dimension, error) {
+func (m *MockFilterClient) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (filter.Dimensions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDimensions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID)
-	ret0, _ := ret[0].([]filter.Dimension)
+	ret := m.ctrl.Call(m, "GetDimensions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, q)
+	ret0, _ := ret[0].(filter.Dimensions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDimensions indicates an expected call of GetDimensions
-func (mr *MockFilterClientMockRecorder) GetDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID interface{}) *gomock.Call {
+func (mr *MockFilterClientMockRecorder) GetDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, q)
 }
 
 // GetDimensionOptions mocks base method
-func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) (filter.DimensionOptions, error) {
+func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (filter.DimensionOptions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, offset, limit)
+	ret := m.ctrl.Call(m, "GetDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
 	ret0, _ := ret[0].(filter.DimensionOptions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDimensionOptions indicates an expected call of GetDimensionOptions
-func (mr *MockFilterClientMockRecorder) GetDimensionOptions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, offset, limit interface{}) *gomock.Call {
+func (mr *MockFilterClientMockRecorder) GetDimensionOptions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, offset, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
 }
 
 // GetJobState mocks base method

--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -91,7 +91,7 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 			}
 
 			indexOfFirstLabelColumn := markingsColumnCount + 2 // +1 for observation, +1 for first codelist column
-			dimensions = []filter.ModelDimension{filter.ModelDimension{Name: "Values"}}
+			dimensions = []filter.ModelDimension{{Name: "Values"}}
 			// add markings column headers
 			for i := 1; i <= markingsColumnCount; i++ {
 				dimensions = append(dimensions, filter.ModelDimension{Name: prev.Headers[i]})

--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -134,7 +134,7 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 			return
 		}
 
-		dataset, err := f.DatasetClient.Get(req.Context(), userAccessToken, "", collectionID, datasetID)
+		datasetDetails, err := f.DatasetClient.Get(req.Context(), userAccessToken, "", collectionID, datasetID)
 		if err != nil {
 			log.Event(ctx, "failed to get dataset", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID})
 			setStatusCode(req, w, err)
@@ -147,7 +147,7 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 			return
 		}
 
-		latestURL, err := url.Parse(dataset.Links.LatestVersion.URL)
+		latestURL, err := url.Parse(datasetDetails.Links.LatestVersion.URL)
 		if err != nil {
 			log.Event(ctx, "failed to parse latest version href", log.ERROR, log.Error(err), log.Data{"filter_output_id": filterOutputID})
 			setStatusCode(req, w, err)
@@ -155,7 +155,7 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 		}
 		latestPath := strings.TrimPrefix(latestURL.Path, f.APIRouterVersion)
 
-		p := mapper.CreatePreviewPage(req, dimensions, fj, dataset, filterOutputID, datasetID, ver.ReleaseDate, f.APIRouterVersion, f.EnableDatasetPreview, lang)
+		p := mapper.CreatePreviewPage(req, dimensions, fj, datasetDetails, filterOutputID, datasetID, ver.ReleaseDate, f.APIRouterVersion, f.EnableDatasetPreview, lang)
 
 		editionDetails, err := f.DatasetClient.GetEdition(req.Context(), userAccessToken, "", collectionID, datasetID, edition)
 		if err != nil {
@@ -193,7 +193,7 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 		}
 
 		for _, dim := range dims.Items {
-			opts, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, 0, 0)
+			opts, err := f.DatasetClient.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, dataset.QueryParams{})
 			if err != nil {
 				log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err), log.Data{"dimension": dim.Name, "dataset_id": datasetID, "edition": edition, "version": version})
 				setStatusCode(req, w, err)
@@ -311,7 +311,7 @@ func (f *Filter) getMetadataTextSize(ctx context.Context, userAccessToken, colle
 	b.WriteString(metadata.ToString())
 	b.WriteString("Dimensions:\n")
 	for _, dimension := range dimensions.Items {
-		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, 0, 0)
+		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, dataset.QueryParams{})
 		if err != nil {
 			return 0, err
 		}

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -104,11 +104,13 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(testSelectedOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), nil)
 
@@ -133,7 +135,8 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, errors.New("get dimensions options error"))
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, errors.New("get dimensions options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -147,7 +150,8 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, errors.New("dataset get error"))
 
 			w := callSearch()
@@ -162,7 +166,8 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, errors.New("get version error"))
 
@@ -178,10 +183,12 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(testSelectedOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, errors.New("get options error"))
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, errors.New("get options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -195,10 +202,12 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(testSelectedOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, errors.New("search api error"))
 
 			w := callSearch()
@@ -213,10 +222,12 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(testSelectedOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(testSelectedOptions, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
+				dataset.QueryParams{IDs: []string{"op1", "op2"}}).Return(testDatasetOptions, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), errors.New("renderer error"))
@@ -234,7 +245,8 @@ func TestUnitSearch(t *testing.T) {
 					},
 				},
 			}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, nil)
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -360,7 +372,8 @@ func TestSearchUpdate(t *testing.T) {
 			expectedRemoveOptions := []string{"clothing-4"}
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(searchModel, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filterOptions, nil)
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filterOptions, nil)
 			mfc.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
 				ItemsEq(expectedAddOptions), ItemsEq(expectedRemoveOptions), batchSize).Return(nil)
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
@@ -371,7 +384,8 @@ func TestSearchUpdate(t *testing.T) {
 		Convey("When GetDimensionOptions fails with a generic error, then the execution is aborted and an Internal Server Error is returned.", func() {
 			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(&search.Model{}, nil)
-			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, errors.New("Error getting dimention options"))
+			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
+				filter.QueryParams{Offset: 0, Limit: batchSize}).Return(filter.DimensionOptions{}, errors.New("Error getting dimention options"))
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -77,7 +77,7 @@ func TestUnitSearch(t *testing.T) {
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), nil)
 
@@ -150,7 +150,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, errors.New("get options error"))
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, errors.New("get options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -167,7 +167,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, errors.New("search api error"))
 
 			w := callSearch()
@@ -185,7 +185,7 @@ func TestUnitSearch(t *testing.T) {
 			mfc.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, 0, batchSize).Return(filter.DimensionOptions{}, nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
-			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, 0, batchSize).Return(dataset.Options{}, nil)
+			mdc.EXPECT().GetOptions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name, dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(dataset.Options{}, nil)
 			msc.EXPECT().Dimension(ctx, datasetID, edition, version, name, query, expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
 			mrc.EXPECT().Do("dataset-filter/hierarchy", gomock.Any()).Return([]byte(expectedHTML), errors.New("renderer error"))

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dates"
@@ -214,7 +215,7 @@ func (f *Filter) Time() http.HandlerFunc {
 			return
 		}
 
-		dataset, err := f.DatasetClient.Get(ctx, userAccessToken, "", collectionID, datasetID)
+		datasetDetails, err := f.DatasetClient.Get(ctx, userAccessToken, "", collectionID, datasetID)
 		if err != nil {
 			log.Event(ctx, "failed to get dataset", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID})
 			setStatusCode(req, w, err)
@@ -227,7 +228,7 @@ func (f *Filter) Time() http.HandlerFunc {
 			return
 		}
 
-		allValues, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, 0, 0)
+		allValues, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimensionName, dataset.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get options from dataset client", log.ERROR, log.Error(err),
 				log.Data{"dimension": dimensionName, "dataset_id": datasetID, "edition": edition, "version": version})
@@ -257,7 +258,7 @@ func (f *Filter) Time() http.HandlerFunc {
 			return
 		}
 
-		p, err := mapper.CreateTimePage(req, fj, dataset, ver, allValues, selValues.Items, dims, datasetID, f.APIRouterVersion, lang)
+		p, err := mapper.CreateTimePage(req, fj, datasetDetails, ver, allValues, selValues.Items, dims, datasetID, f.APIRouterVersion, lang)
 		if err != nil {
 			log.Event(ctx, "failed to map data to page", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dataset_id": datasetID, "dimension": dimensionName})
 			setStatusCode(req, w, err)

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
@@ -22,6 +23,13 @@ func TestUpdateTime(t *testing.T) {
 	const mockFilterID = ""
 	const batchSize = 100
 
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockServiceAuthToken,
+		DownloadServiceURL:   "",
+		BatchSizeLimit:       batchSize,
+		EnableDatasetPreview: false,
+	}
+
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := gomock.Any()
@@ -34,7 +42,7 @@ func TestUpdateTime(t *testing.T) {
 		req.Header.Add(dprequest.FlorenceHeaderKey, mockUserAuthToken)
 		req.Header.Add(dprequest.CollectionIDHeaderKey, mockCollectionID)
 		w := httptest.NewRecorder()
-		f := NewFilter(nil, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+		f := NewFilter(nil, mockFilterClient, mockDatasetClient, nil, nil, nil, "/v1", cfg)
 		f.UpdateTime().ServeHTTP(w, req)
 		return w
 	}

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -93,7 +93,7 @@ func TestUpdateTime(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time", 0, 0).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time", dataset.QueryParams{}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", filterOptions).Return(nil)
 		formData := "latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&month-single=Select&year-single=Select&time-selection=range&start-month=January&start-year=2000&end-month=March&end-year=2000&start-year-grouped=Select&end-year-grouped=Select&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -101,7 +101,8 @@ func TestUpdateTime(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time",
+			dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", filterOptions).Return(nil)
 		formData := "latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&month-single=Select&year-single=Select&time-selection=range&start-month=January&start-year=2000&end-month=March&end-year=2000&start-year-grouped=Select&end-year-grouped=Select&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -101,7 +101,7 @@ func TestUpdateTime(t *testing.T) {
 		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
-		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time", dataset.QueryParams{}).Return(datasetOptions, nil)
+		mockDatasetClient.EXPECT().GetOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time", dataset.QueryParams{Offset: 0, Limit: batchSize}).Return(datasetOptions, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", filterOptions).Return(nil)
 		formData := "latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&month-single=Select&year-single=Select&time-selection=range&start-month=January&start-year=2000&end-month=March&end-year=2000&start-year-grouped=Select&end-year-grouped=Select&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockFilterClient, mockDatasetClient)

--- a/handlers/update-version.go
+++ b/handlers/update-version.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/filter"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
@@ -28,7 +29,7 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 			return
 		}
 
-		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID)
+		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, filter.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -64,7 +65,7 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 			return
 		}
 
-		for _, dim := range dims {
+		for _, dim := range dims.Items {
 			if err := f.FilterClient.AddDimension(req.Context(), userAccessToken, "", collectionID, newFilterID, dim.Name); err != nil {
 				log.Event(ctx, "failed to add dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)

--- a/handlers/update-version.go
+++ b/handlers/update-version.go
@@ -84,7 +84,7 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 				return f.FilterClient.PatchDimensionValues(req.Context(), userAccessToken, "", collectionID, newFilterID, dim.Name, vals, []string{}, f.BatchSize)
 			}
 
-			// Call filter API GetOptions in bathes and aggregate the responses
+			// Call filter API GetOptions in batches and aggregate the responses
 			if err := f.BatchProcessDimensionOptionsFromFilterAPI(req.Context(), userAccessToken, collectionID, filterID, dim.Name, processBatch); err != nil {
 				log.Event(ctx, "failed to get and process options from filter client in batches", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)

--- a/handlers/update-version_test.go
+++ b/handlers/update-version_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -21,6 +22,13 @@ func TestUseLatest(t *testing.T) {
 	filterID := "current-filter-id"
 	mockNewFilterID := "new-filter-id"
 	batchSize := 100
+
+	cfg := &config.Config{
+		SearchAPIAuthToken:   mockServiceAuthToken,
+		DownloadServiceURL:   "",
+		BatchSizeLimit:       batchSize,
+		EnableDatasetPreview: false,
+	}
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -55,7 +63,7 @@ func TestUseLatest(t *testing.T) {
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day", []string{mockDimensionOption.Items[0].Option}).Return(nil)
 
 		mockRenderer := NewMockRenderer(mockCtrl)
-		f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, mockServiceAuthToken, "", "/v1", false, batchSize)
+		f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, "/v1", cfg)
 
 		router := mux.NewRouter()
 		router.Path("/filters/{filterID}/use-latest-version").HandlerFunc(f.UseLatest())

--- a/handlers/update-version_test.go
+++ b/handlers/update-version_test.go
@@ -55,11 +55,16 @@ func TestUseLatest(t *testing.T) {
 		mockFilterClient := NewMockFilterClient(mockCtrl)
 		mockDatasetClient := NewMockDatasetClient(mockCtrl)
 		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
-		mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID).Return([]filter.Dimension{{Name: "Day"}}, nil)
+		mockFilterClient.EXPECT().GetDimensions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID,
+			filter.QueryParams{}).Return(
+			filter.Dimensions{
+				Items: []filter.Dimension{{Name: "Day"}},
+			}, nil)
 		mockDatasetClient.EXPECT().GetEdition(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016").Return(dataset.Edition{Links: mockEditionLinks}, nil)
 		mockFilterClient.EXPECT().CreateBlueprint(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, "95c4669b-3ae9-4ba7-b690-87e890a1c67c", "2016", "2", []string{}).Return(mockNewFilterID, nil)
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day").Return(nil)
-		mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", 0, batchSize).Return(mockDimensionOption, nil)
+		mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day",
+			filter.QueryParams{Offset: 0, Limit: batchSize}).Return(mockDimensionOption, nil)
 		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day", []string{mockDimensionOption.Items[0].Option}).Return(nil)
 
 		mockRenderer := NewMockRenderer(mockCtrl)

--- a/handlers/update-version_test.go
+++ b/handlers/update-version_test.go
@@ -65,7 +65,7 @@ func TestUseLatest(t *testing.T) {
 		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day").Return(nil)
 		mockFilterClient.EXPECT().GetDimensionOptions(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day",
 			filter.QueryParams{Offset: 0, Limit: batchSize}).Return(mockDimensionOption, nil)
-		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day", []string{mockDimensionOption.Items[0].Option}).Return(nil)
+		mockFilterClient.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockNewFilterID, "Day", []string{mockDimensionOption.Items[0].Option}, []string{}, batchSize).Return(nil)
 
 		mockRenderer := NewMockRenderer(mockCtrl)
 		f := NewFilter(mockRenderer, mockFilterClient, mockDatasetClient, nil, nil, nil, "/v1", cfg)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -408,7 +408,7 @@ func getIDNameLookupFromHierarchy(vals hierarchyClient.Model) map[string]string 
 }
 
 // CreateAgePage creates an age selector page based on api responses
-func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals []filter.DimensionOption, dims dataset.VersionDimensions, datasetID, apiRouterVersion, lang string) (age.Page, error) {
+func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, v dataset.Version, allVals dataset.Options, selVals filter.DimensionOptions, dims dataset.VersionDimensions, datasetID, apiRouterVersion, lang string) (age.Page, error) {
 	var p age.Page
 	p.BetaBannerEnabled = true
 
@@ -479,7 +479,7 @@ func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, 
 	for _, ageVal := range ages {
 		var isSelected bool
 		ageString := strconv.Itoa(ageVal)
-		for _, selVal := range selVals {
+		for _, selVal := range selVals.Items {
 			if selVal.Option == labelIDs[ageString] {
 				isSelected = true
 			}
@@ -496,7 +496,7 @@ func CreateAgePage(req *http.Request, f filter.Model, d dataset.DatasetDetails, 
 
 	if len(p.Data.Oldest) > 0 {
 		var isSelected bool
-		for _, selVal := range selVals {
+		for _, selVal := range selVals.Items {
 			if selVal.Option == labelIDs[p.Data.Oldest] {
 				isSelected = true
 			}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -50,8 +50,7 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 	}
 
 	filter := handlers.NewFilter(clients.Renderer, clients.Filter, clients.Dataset,
-		clients.Hierarchy, clients.Search, v, cfg.SearchAPIAuthToken, cfg.DownloadServiceURL, apiRouterVersion,
-		cfg.EnableDatasetPreview, cfg.BatchSizeLimit)
+		clients.Hierarchy, clients.Search, v, apiRouterVersion, cfg)
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(clients.HealthcheckHandler)
 


### PR DESCRIPTION
### What

Upgraded `dp-api-clients-go` dependency to v1.32.0 in order to match filter API response with `GetDimensions` pagination

Improved efficiency by batch processing where needed, and requesting only the necessary information from APIs where possible:
- getIDNameLookupFromDatasetAPI now gets only the required IDs from dataset API (in batches of `MaxDatasetOptions`) instead of getting all options in batches
- generalised dataset API batch processing (`BatchProcessDimensionOptionsFromDatasetAPI`):
  - used to accumulate results in GetDimensionOptionsFromDatasetAPI
  - used in dimensions.go addAll to do the dataset.Get+filter.Patch(add) options in batches if needed
- time.go, age.go and dimensions.go now get the count of allValues before deciding if we need to continue, and get all values (in batches) as late as possible, only if we do need them.
- Refactored NewFilter to obtain the new `MaxDatasetOptions` value from config

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone