### PR TITLE
Feature/etag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
 )
+
+replace github.com/ONSdigital/dp-api-clients-go => ../dp-api-clients-go

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-dataset-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.32.11-0.20210127150434-e9fe27f4a4ae
+	github.com/ONSdigital/dp-api-clients-go v1.33.0
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.29.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.32.11-0.20210127150434-e9fe27f4a4ae h1:Yiw9x1Dtg17DiRIPLxoQNJJaTtC/+0BTQ6BBMYwGiVY=
-github.com/ONSdigital/dp-api-clients-go v1.32.11-0.20210127150434-e9fe27f4a4ae/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.33.0 h1:VVWJZSpmHOJvXUETwgAcFaizW6voxRU8RbsmPHma4GU=
+github.com/ONSdigital/dp-api-clients-go v1.33.0/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0 h1:jMM5drrwcOK5H0DTL8JpLOZm2rw+VJrz+vI9h2GQ8nQ=

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 	"github.com/ONSdigital/log.go/log"
 
@@ -27,12 +28,14 @@ func (f *Filter) UpdateAge() http.HandlerFunc {
 		filterID := vars["filterID"]
 		dimensionName := "age"
 
-		if err := f.FilterClient.RemoveDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName); err != nil {
+		eTag, err := f.FilterClient.RemoveDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName, headers.IfMatchAnyETag)
+		if err != nil {
 			log.Event(ctx, "failed to remove dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)
 			return
 		}
-		if err := f.FilterClient.AddDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName); err != nil {
+		eTag, err = f.FilterClient.AddDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName, eTag)
+		if err != nil {
 			log.Event(ctx, "failed to add dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)
 			return

--- a/handlers/age.go
+++ b/handlers/age.go
@@ -242,7 +242,7 @@ func (f *Filter) Age() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -21,22 +21,22 @@ type ClientError interface {
 // FilterClient contains the methods expected for a filter client
 type FilterClient interface {
 	Checker(ctx context.Context, check *health.CheckState) error
-	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (dims filter.Dimensions, err error)
-	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (fdv filter.DimensionOptions, err error)
-	GetDimensionOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, batchSize, maxWorkers int) (opts filter.DimensionOptions, err error)
-	GetDimensionOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, processBatch filter.DimensionOptionsBatchProcessor, batchSize, maxWorkers int) (err error)
-	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, err error)
+	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
+	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (opts filter.DimensionOptions, eTag string, err error)
+	GetDimensionOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, batchSize, maxWorkers int) (opts filter.DimensionOptions, eTag string, err error)
+	GetDimensionOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, processBatch filter.DimensionOptionsBatchProcessor, batchSize, maxWorkers int, checkETag bool) (eTag string, err error)
+	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, eTag string, err error)
 	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (f filter.Model, err error)
-	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, err error)
-	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value string) error
-	RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value string) error
-	RemoveDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (err error)
-	AddDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (err error)
-	SetDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, options []string) error
-	PatchDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, addValues, removeValues []string, batchSize int) error
-	UpdateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID string, m filter.Model, doSubmit bool) (filter.Model, error)
-	CreateBlueprint(context.Context, string, string, string, string, string, string, string, []string) (string, error)
-	GetPreview(context.Context, string, string, string, string, string) (filter.Preview, error)
+	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, eTag string, err error)
+	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	RemoveDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, ifMatch string) (eTag string, err error)
+	AddDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string) (eTag string, err error)
+	SetDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, options []string, ifMatch string) (eTag string, err error)
+	PatchDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, addValues, removeValues []string, batchSize int, ifMatch string) (latestETag string, err error)
+	UpdateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID string, m filter.Model, doSubmit bool, ifMatch string) (filter.Model, string, error)
+	CreateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string) (filterID, eTag string, err error)
+	GetPreview(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (p filter.Preview, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"github.com/ONSdigital/dp-api-clients-go/hierarchy"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dates"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
@@ -34,7 +35,7 @@ func (f *Filter) GetAllDimensionOptionsJSON() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		fj, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		fj, _, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -123,16 +124,26 @@ func (f *Filter) GetSelectedDimensionOptionsJSON() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		opts, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
+		opts, eTag0, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to get dimension options", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
+			setStatusCode(req, w, err)
+			// TODO we might want to retry this handler on ErrBatchETagMismatch?
+			return
+		}
+
+		fj, eTag1, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		if err != nil {
+			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		fj, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
-		if err != nil {
-			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
+		// TODO we might want to retry this handler if eTags don't match
+		if eTag0 != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "dimension": name, "e_tag_0": eTag0, "e_tag_1": eTag1})
 			setStatusCode(req, w, err)
 			return
 		}
@@ -193,8 +204,7 @@ func (f *Filter) GetSelectedDimensionOptionsJSON() http.HandlerFunc {
 
 }
 
-// DimensionSelector controls the render of the range selector template
-// Contains stubbed data for now - page to be populated by the API
+// DimensionSelector controls the render of the range selector template using data from Dataset API and Filter API
 func (f *Filter) DimensionSelector() http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
 		vars := mux.Vars(req)
@@ -202,7 +212,7 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		fj, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		fj, eTag0, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -266,9 +276,19 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 			return
 		}
 
-		selectedValues, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
+		selectedValues, eTag1, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
+			setStatusCode(req, w, err)
+			// TODO we might want to retry this handler on ErrBatchETagMismatch?
+			return
+		}
+
+		// TODO we might want to retry this handler if eTags don't match
+		if eTag0 != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "dimension": name, "e_tag_0": eTag0, "e_tag_1": eTag1})
 			setStatusCode(req, w, err)
 			return
 		}
@@ -480,10 +500,11 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL, u
 	filterID := vars["filterID"]
 	ctx := req.Context()
 
-	fj, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+	fj, eTag, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 	if err != nil {
 		log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 		setStatusCode(req, w, err)
+		// TODO we might want to retry this handler on ErrBatchETagMismatch?
 		return
 	}
 
@@ -510,10 +531,12 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL, u
 		}
 		// first batch, will overwrite any existing values in filter API
 		if batch.Offset == 0 {
-			return false, f.FilterClient.SetDimensionValues(req.Context(), userAccessToken, "", collectionID, filterID, name, options)
+			eTag, err = f.FilterClient.SetDimensionValues(req.Context(), userAccessToken, "", collectionID, filterID, name, options, eTag)
+			return false, err
 		}
 		// the rest of batches will be added to the existing items in filter API via patch operations
-		return false, f.FilterClient.PatchDimensionValues(req.Context(), userAccessToken, "", collectionID, filterID, name, options, []string{}, f.BatchSize)
+		eTag, err = f.FilterClient.PatchDimensionValues(req.Context(), userAccessToken, "", collectionID, filterID, name, options, []string{}, f.BatchSize, eTag)
+		return false, err
 	}
 
 	// call dataset API GetOptions in batches, and process each batch to add the options to filter API
@@ -563,7 +586,8 @@ func (f *Filter) AddList() http.HandlerFunc {
 			options = append(options, k)
 		}
 
-		if err := f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, options); err != nil {
+		_, err := f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, options, headers.IfMatchAnyETag)
+		if err != nil {
 			log.Event(ctx, "failed to add dimension values", log.WARN, log.Error(err))
 		}
 
@@ -574,7 +598,7 @@ func (f *Filter) AddList() http.HandlerFunc {
 
 func (f *Filter) getDimensionValues(ctx context.Context, userAccessToken, collectionID, filterID, name string) (values []string, labelIDMap map[string]string, err error) {
 
-	fj, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
+	fj, _, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
 	if err != nil {
 		return
 	}
@@ -614,13 +638,15 @@ func (f *Filter) DimensionRemoveAll() http.HandlerFunc {
 
 		log.Event(ctx, "attempting to remove all options from dimension", log.INFO, log.Data{"dimension": name, "filterID": filterID})
 
-		if err := f.FilterClient.RemoveDimension(req.Context(), userAccessToken, "", collectionID, filterID, name); err != nil {
+		eTag, err := f.FilterClient.RemoveDimension(req.Context(), userAccessToken, "", collectionID, filterID, name, headers.IfMatchAnyETag)
+		if err != nil {
 			log.Event(ctx, "failed to remove dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		if err := f.FilterClient.AddDimension(req.Context(), userAccessToken, "", collectionID, filterID, name); err != nil {
+		_, err = f.FilterClient.AddDimension(req.Context(), userAccessToken, "", collectionID, filterID, name, eTag)
+		if err != nil {
 			log.Event(ctx, "failed to add dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
 			return
@@ -641,7 +667,8 @@ func (f *Filter) DimensionRemoveOne() http.HandlerFunc {
 		option := vars["option"]
 		ctx := req.Context()
 
-		if err := f.FilterClient.RemoveDimensionValue(req.Context(), userAccessToken, "", collectionID, filterID, name, option); err != nil {
+		_, err := f.FilterClient.RemoveDimensionValue(req.Context(), userAccessToken, "", collectionID, filterID, name, option, headers.IfMatchAnyETag)
+		if err != nil {
 			log.Event(ctx, "failed to remove dimension option", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name, "option": option})
 			setStatusCode(req, w, err)
 			return

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -128,7 +128,7 @@ func (f *Filter) GetSelectedDimensionOptionsJSON() http.HandlerFunc {
 		if err != nil {
 			log.Event(ctx, "failed to get dimension options", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
-			// TODO we might want to retry this handler on ErrBatchETagMismatch?
+			// The user might want to retry this handler on ErrBatchETagMismatch
 			return
 		}
 
@@ -139,7 +139,7 @@ func (f *Filter) GetSelectedDimensionOptionsJSON() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
@@ -280,11 +280,11 @@ func (f *Filter) DimensionSelector() http.HandlerFunc {
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)
-			// TODO we might want to retry this handler on ErrBatchETagMismatch?
+			// The user might want to retry this handler on ErrBatchETagMismatch
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
@@ -504,7 +504,7 @@ func (f *Filter) addAll(w http.ResponseWriter, req *http.Request, redirectURL, u
 	if err != nil {
 		log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 		setStatusCode(req, w, err)
-		// TODO we might want to retry this handler on ErrBatchETagMismatch?
+		// The user might want to retry this handler on ErrBatchETagMismatch
 		return
 	}
 

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -41,7 +41,7 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
@@ -82,7 +82,7 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 				return
 			}
 
-			// TODO we might want to retry this handler if eTags don't match
+			// The user might want to retry this handler if eTags don't match
 			if eTag2 != eTag1 {
 				err := errors.New("inconsistent filter data")
 				log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),

--- a/handlers/filter-overview_test.go
+++ b/handlers/filter-overview_test.go
@@ -58,11 +58,11 @@ func TestUnitFilterOverview(t *testing.T) {
 				filter.QueryParams{}).Return(
 				filter.Dimensions{
 					Items: []filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}},
-				}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", batchSize, maxWorkers).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", batchSize, maxWorkers).Return(filter.DimensionOptions{}, nil)
-			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", batchSize, maxWorkers).Return(filterGeographyOptions, nil)
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, nil)
+				}, testETag(0), nil)
+			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", batchSize, maxWorkers).Return(filterGeographyOptions, testETag(0), nil)
+			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", batchSize, maxWorkers).Return(filter.DimensionOptions{}, testETag(0), nil)
+			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", batchSize, maxWorkers).Return(filter.DimensionOptions{}, testETag(0), nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, mockDownloadToken, mockCollectionID, filterID).Return(filter.Model{Links: filter.Links{Version: filter.Link{HRef: "/v1/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/1"}}}, testETag(0), nil)
 
 			// expected calls to dataset api: get options only for options that were found in filter api. Get, GetVersion and GetEdition
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
@@ -96,13 +96,13 @@ func TestUnitFilterOverview(t *testing.T) {
 				filter.QueryParams{}).Return(
 				filter.Dimensions{
 					Items: []filter.Dimension{{Name: "geography"}, {Name: "Day"}, {Name: "Goods and Services"}},
-				}, nil)
-			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
-			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day")
-			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services")
-			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services")
-			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography")
-			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography")
+				}, testETag(0), nil)
+			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", testETag(0)).Return(testETag(1), nil)
+			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "geography", testETag(1)).Return(testETag(2), nil)
+			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", testETag(2)).Return(testETag(3), nil)
+			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Day", testETag(3)).Return(testETag(4), nil)
+			mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", testETag(4)).Return(testETag(5), nil)
+			mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, filterID, "Goods and Services", testETag(5)).Return(testETag(6), nil)
 
 			req := httptest.NewRequest("GET", "/filters/12345/dimensions/clear-all", nil)
 			w := httptest.NewRecorder()

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -219,7 +219,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -45,7 +46,7 @@ func (f *Filter) HierarchyUpdate() http.HandlerFunc {
 			}
 		}
 
-		fil, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		fil, eTag, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -53,12 +54,12 @@ func (f *Filter) HierarchyUpdate() http.HandlerFunc {
 		}
 
 		if len(req.Form["add-all"]) > 0 {
-			f.addAllHierarchyLevel(w, req, fil, name, code, redirectURI, userAccessToken, collectionID)
+			f.addAllHierarchyLevel(w, req, fil, name, code, redirectURI, userAccessToken, collectionID, eTag)
 			return
 		}
 
 		if len(req.Form["remove-all"]) > 0 {
-			f.removeAllHierarchyLevel(w, req, fil, name, code, redirectURI, userAccessToken, collectionID)
+			f.removeAllHierarchyLevel(w, req, fil, name, code, redirectURI, userAccessToken, collectionID, eTag)
 			return
 		}
 
@@ -81,7 +82,7 @@ func (f *Filter) HierarchyUpdate() http.HandlerFunc {
 		var addOptions []string
 		addOptions = getOptionsAndRedirect(req.Form, &redirectURI)
 
-		err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, addOptions, removeOptions, f.BatchSize)
+		_, err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, addOptions, removeOptions, f.BatchSize, eTag)
 		if err != nil {
 			log.Event(ctx, "failed to patch dimension values", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name, "code": code})
 			setStatusCode(req, w, err)
@@ -110,7 +111,7 @@ func (f *Filter) buildHierarchyModel(ctx context.Context, fil filter.Model, name
 	return h, err
 }
 
-func (f *Filter) addAllHierarchyLevel(w http.ResponseWriter, req *http.Request, fil filter.Model, name, code, redirectURI, userAccessToken, collectionID string) {
+func (f *Filter) addAllHierarchyLevel(w http.ResponseWriter, req *http.Request, fil filter.Model, name, code, redirectURI, userAccessToken, collectionID, eTag string) {
 
 	ctx := req.Context()
 	var err error
@@ -135,14 +136,15 @@ func (f *Filter) addAllHierarchyLevel(w http.ResponseWriter, req *http.Request, 
 	for _, child := range h.Children {
 		options = append(options, child.Links.Code.ID)
 	}
-	if err := f.FilterClient.SetDimensionValues(req.Context(), userAccessToken, "", collectionID, fil.FilterID, name, options); err != nil {
+	_, err = f.FilterClient.SetDimensionValues(req.Context(), userAccessToken, "", collectionID, fil.FilterID, name, options, eTag)
+	if err != nil {
 		log.Event(ctx, "failed to add dimension values", log.ERROR, log.Error(err))
 	}
 
 	http.Redirect(w, req, redirectURI, 302)
 }
 
-func (f *Filter) removeAllHierarchyLevel(w http.ResponseWriter, req *http.Request, fil filter.Model, name, code, redirectURI, userAccessToken, collectionID string) {
+func (f *Filter) removeAllHierarchyLevel(w http.ResponseWriter, req *http.Request, fil filter.Model, name, code, redirectURI, userAccessToken, collectionID, eTag string) {
 	ctx := req.Context()
 	var h hierarchy.Model
 	var err error
@@ -169,7 +171,8 @@ func (f *Filter) removeAllHierarchyLevel(w http.ResponseWriter, req *http.Reques
 	}
 
 	// remove all items
-	if err := f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, fil.FilterID, name, []string{}, removeOptions, f.BatchSize); err != nil {
+	_, err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, fil.FilterID, name, []string{}, removeOptions, f.BatchSize, eTag)
+	if err != nil {
 		log.Event(ctx, "failed to remove dimension values using a patch", log.ERROR, log.Error(err), log.Data{"filter_id": fil.FilterID, "dimension": name, "code": code, "options": removeOptions})
 	}
 
@@ -185,7 +188,7 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 		code := vars["code"]
 		ctx := req.Context()
 
-		fil, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		fil, eTag0, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -209,9 +212,18 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 			return
 		}
 
-		selVals, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
+		selVals, eTag1, err := f.FilterClient.GetDimensionOptionsInBatches(req.Context(), userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
+			setStatusCode(req, w, err)
+			return
+		}
+
+		// TODO we might want to retry this handler if eTags don't match
+		if eTag0 != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "dimension": name, "e_tag_0": eTag0, "e_tag_1": eTag1})
 			setStatusCode(req, w, err)
 			return
 		}
@@ -277,7 +289,6 @@ func (f *Filter) Hierarchy() http.HandlerFunc {
 
 		w.Write(templateBytes)
 	})
-
 }
 
 type flatNodes struct {

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -121,10 +121,10 @@ func TestHierarchy(t *testing.T) {
 
 		Convey("Hierarchy called for the root node calls the expected methods and returns the expected marshlled hierarchy page", func() {
 			testTemplate := []byte{1, 2, 3, 4, 5}
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
@@ -140,10 +140,10 @@ func TestHierarchy(t *testing.T) {
 
 		Convey("Hierarchy called for the child node calls the expected methods and returns the expected marshlled hierarchy page", func() {
 			testTemplate := []byte{1, 2, 3, 4, 5}
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(hierarchy.Model{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
@@ -158,10 +158,10 @@ func TestHierarchy(t *testing.T) {
 		})
 
 		Convey("Hierarchy called for the root node calls the expected methods. If dataset GetOption fails, an InternalServerError status code is returned", func() {
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
 			mockFilterClient.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mockDatasetClient.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID).Return(testDatasetDetails, nil)
 			mockDatasetClient.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersion, nil)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, mockDatasetID, mockEdition, mockVersion).Return(testVersionDimensions, nil)
@@ -253,9 +253,9 @@ func TestHierarchyUpdate(t *testing.T) {
 				"opt5": []string{"v51", "v52", "v53"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockFilterClient.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{"opt3", "opt4", "opt5"}), []string{""}, batchSize).Return(nil)
+				ItemsEq([]string{"opt3", "opt4", "opt5"}), []string{""}, batchSize, testETag(0)).Return(testETag(1), nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(hierarchy.Model{}, nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/update", filterID, dimensionName), testForm)
@@ -270,9 +270,9 @@ func TestHierarchyUpdate(t *testing.T) {
 				"opt2": []string{"v31", "v32", "v33"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockFilterClient.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{"opt2"}), []string{"opt1"}, batchSize).Return(nil)
+				ItemsEq([]string{"opt2"}), []string{"opt1"}, batchSize, testETag(0)).Return(testETag(1), nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(mockHierarchyModel, nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s/update", filterID, dimensionName, mockCode), testForm)
@@ -286,10 +286,10 @@ func TestHierarchyUpdate(t *testing.T) {
 				"add-all": []string{"true"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(mockHierarchyModel, nil)
 			mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{"opt1", "opt2"})).Return(nil)
+				ItemsEq([]string{"opt1", "opt2"}), testETag(0)).Return(testETag(1), nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/update", filterID, dimensionName), testForm)
 
@@ -302,10 +302,10 @@ func TestHierarchyUpdate(t *testing.T) {
 				"add-all": []string{"true"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(mockHierarchyModel, nil)
 			mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{"opt1", "opt2"})).Return(nil)
+				ItemsEq([]string{"opt1", "opt2"}), testETag(0)).Return(testETag(1), nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s/update", filterID, dimensionName, mockCode), testForm)
 
@@ -318,10 +318,10 @@ func TestHierarchyUpdate(t *testing.T) {
 				"remove-all": []string{"true"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, dimensionName).Return(mockHierarchyModel, nil)
 			mockFilterClient.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{}), ItemsEq([]string{"opt1", "opt2"}), batchSize).Return(nil)
+				ItemsEq([]string{}), ItemsEq([]string{"opt1", "opt2"}), batchSize, testETag(0)).Return(testETag(1), nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/update", filterID, dimensionName), testForm)
 
@@ -334,10 +334,10 @@ func TestHierarchyUpdate(t *testing.T) {
 				"remove-all": []string{"true"},
 			}
 
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, dimensionName, mockCode).Return(mockHierarchyModel, nil)
 			mockFilterClient.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, dimensionName,
-				ItemsEq([]string{}), ItemsEq([]string{"opt1", "opt2"}), batchSize).Return(nil)
+				ItemsEq([]string{}), ItemsEq([]string{"opt1", "opt2"}), batchSize, testETag(0)).Return(testETag(1), nil)
 
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/%s/update", filterID, dimensionName, mockCode), testForm)
 
@@ -347,7 +347,7 @@ func TestHierarchyUpdate(t *testing.T) {
 
 		Convey("Then if GetJobState fails, the hierarchy update is aborted and a 500 status code is returned", func() {
 			errGetJobState := errors.New("error getting job state")
-			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filter.Model{}, errGetJobState)
+			mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filter.Model{}, "", errGetJobState)
 			w := callUpdateHierarchy(fmt.Sprintf("/filters/%s/dimensions/%s/update", filterID, dimensionName), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -104,12 +104,13 @@ func (mr *MockFilterClientMockRecorder) Checker(ctx, check interface{}) *gomock.
 }
 
 // GetDimensions mocks base method
-func (m *MockFilterClient) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (filter.Dimensions, error) {
+func (m *MockFilterClient) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q filter.QueryParams) (filter.Dimensions, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDimensions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, q)
 	ret0, _ := ret[0].(filter.Dimensions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetDimensions indicates an expected call of GetDimensions
@@ -119,12 +120,13 @@ func (mr *MockFilterClientMockRecorder) GetDimensions(ctx, userAuthToken, servic
 }
 
 // GetDimensionOptions mocks base method
-func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (filter.DimensionOptions, error) {
+func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q filter.QueryParams) (filter.DimensionOptions, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
 	ret0, _ := ret[0].(filter.DimensionOptions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetDimensionOptions indicates an expected call of GetDimensionOptions
@@ -134,12 +136,13 @@ func (mr *MockFilterClientMockRecorder) GetDimensionOptions(ctx, userAuthToken, 
 }
 
 // GetDimensionOptionsInBatches mocks base method
-func (m *MockFilterClient) GetDimensionOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, batchSize, maxWorkers int) (filter.DimensionOptions, error) {
+func (m *MockFilterClient) GetDimensionOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, batchSize, maxWorkers int) (filter.DimensionOptions, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDimensionOptionsInBatches", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, batchSize, maxWorkers)
 	ret0, _ := ret[0].(filter.DimensionOptions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetDimensionOptionsInBatches indicates an expected call of GetDimensionOptionsInBatches
@@ -149,26 +152,28 @@ func (mr *MockFilterClientMockRecorder) GetDimensionOptionsInBatches(ctx, userAu
 }
 
 // GetDimensionOptionsBatchProcess mocks base method
-func (m *MockFilterClient) GetDimensionOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, processBatch filter.DimensionOptionsBatchProcessor, batchSize, maxWorkers int) error {
+func (m *MockFilterClient) GetDimensionOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, processBatch filter.DimensionOptionsBatchProcessor, batchSize, maxWorkers int, checkETag bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDimensionOptionsBatchProcess", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetDimensionOptionsBatchProcess", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers, checkETag)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetDimensionOptionsBatchProcess indicates an expected call of GetDimensionOptionsBatchProcess
-func (mr *MockFilterClientMockRecorder) GetDimensionOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers interface{}) *gomock.Call {
+func (mr *MockFilterClientMockRecorder) GetDimensionOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers, checkETag interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptionsBatchProcess", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptionsBatchProcess), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptionsBatchProcess", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptionsBatchProcess), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, processBatch, batchSize, maxWorkers, checkETag)
 }
 
 // GetJobState mocks base method
-func (m *MockFilterClient) GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (filter.Model, error) {
+func (m *MockFilterClient) GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (filter.Model, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobState", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID)
 	ret0, _ := ret[0].(filter.Model)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetJobState indicates an expected call of GetJobState
@@ -193,12 +198,13 @@ func (mr *MockFilterClientMockRecorder) GetOutput(ctx, userAuthToken, serviceAut
 }
 
 // GetDimension mocks base method
-func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (filter.Dimension, error) {
+func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (filter.Dimension, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDimension", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
 	ret0, _ := ret[0].(filter.Dimension)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetDimension indicates an expected call of GetDimension
@@ -208,132 +214,140 @@ func (mr *MockFilterClientMockRecorder) GetDimension(ctx, userAuthToken, service
 }
 
 // AddDimensionValue mocks base method
-func (m *MockFilterClient) AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value string) error {
+func (m *MockFilterClient) AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddDimensionValue indicates an expected call of AddDimensionValue
-func (mr *MockFilterClientMockRecorder) AddDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).AddDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value)
-}
-
-// RemoveDimensionValue mocks base method
-func (m *MockFilterClient) RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveDimensionValue indicates an expected call of RemoveDimensionValue
-func (mr *MockFilterClientMockRecorder) RemoveDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).RemoveDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value)
-}
-
-// RemoveDimension mocks base method
-func (m *MockFilterClient) RemoveDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveDimension", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveDimension indicates an expected call of RemoveDimension
-func (mr *MockFilterClientMockRecorder) RemoveDimension(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDimension", reflect.TypeOf((*MockFilterClient)(nil).RemoveDimension), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
-}
-
-// AddDimension mocks base method
-func (m *MockFilterClient) AddDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddDimension", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddDimension indicates an expected call of AddDimension
-func (mr *MockFilterClientMockRecorder) AddDimension(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimension", reflect.TypeOf((*MockFilterClient)(nil).AddDimension), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
-}
-
-// SetDimensionValues mocks base method
-func (m *MockFilterClient) SetDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, options []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDimensionValues", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetDimensionValues indicates an expected call of SetDimensionValues
-func (mr *MockFilterClientMockRecorder) SetDimensionValues(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDimensionValues", reflect.TypeOf((*MockFilterClient)(nil).SetDimensionValues), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options)
-}
-
-// PatchDimensionValues mocks base method
-func (m *MockFilterClient) PatchDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, addValues, removeValues []string, batchSize int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchDimensionValues", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PatchDimensionValues indicates an expected call of PatchDimensionValues
-func (mr *MockFilterClientMockRecorder) PatchDimensionValues(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDimensionValues", reflect.TypeOf((*MockFilterClient)(nil).PatchDimensionValues), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize)
-}
-
-// UpdateBlueprint mocks base method
-func (m_2 *MockFilterClient) UpdateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID string, m filter.Model, doSubmit bool) (filter.Model, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "UpdateBlueprint", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit)
-	ret0, _ := ret[0].(filter.Model)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBlueprint indicates an expected call of UpdateBlueprint
-func (mr *MockFilterClientMockRecorder) UpdateBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBlueprint", reflect.TypeOf((*MockFilterClient)(nil).UpdateBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit)
-}
-
-// CreateBlueprint mocks base method
-func (m *MockFilterClient) CreateBlueprint(arg0 context.Context, arg1, arg2, arg3, arg4, arg5, arg6, arg7 string, arg8 []string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBlueprint", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret := m.ctrl.Call(m, "AddDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateBlueprint indicates an expected call of CreateBlueprint
-func (mr *MockFilterClientMockRecorder) CreateBlueprint(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+// AddDimensionValue indicates an expected call of AddDimensionValue
+func (mr *MockFilterClientMockRecorder) AddDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateBlueprint), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).AddDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+}
+
+// RemoveDimensionValue mocks base method
+func (m *MockFilterClient) RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveDimensionValue indicates an expected call of RemoveDimensionValue
+func (mr *MockFilterClientMockRecorder) RemoveDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).RemoveDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+}
+
+// RemoveDimension mocks base method
+func (m *MockFilterClient) RemoveDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveDimension", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveDimension indicates an expected call of RemoveDimension
+func (mr *MockFilterClientMockRecorder) RemoveDimension(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDimension", reflect.TypeOf((*MockFilterClient)(nil).RemoveDimension), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, ifMatch)
+}
+
+// AddDimension mocks base method
+func (m *MockFilterClient) AddDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDimension", ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddDimension indicates an expected call of AddDimension
+func (mr *MockFilterClientMockRecorder) AddDimension(ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimension", reflect.TypeOf((*MockFilterClient)(nil).AddDimension), ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch)
+}
+
+// SetDimensionValues mocks base method
+func (m *MockFilterClient) SetDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, options []string, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDimensionValues", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetDimensionValues indicates an expected call of SetDimensionValues
+func (mr *MockFilterClientMockRecorder) SetDimensionValues(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDimensionValues", reflect.TypeOf((*MockFilterClient)(nil).SetDimensionValues), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, options, ifMatch)
+}
+
+// PatchDimensionValues mocks base method
+func (m *MockFilterClient) PatchDimensionValues(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, addValues, removeValues []string, batchSize int, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchDimensionValues", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchDimensionValues indicates an expected call of PatchDimensionValues
+func (mr *MockFilterClientMockRecorder) PatchDimensionValues(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDimensionValues", reflect.TypeOf((*MockFilterClient)(nil).PatchDimensionValues), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, addValues, removeValues, batchSize, ifMatch)
+}
+
+// UpdateBlueprint mocks base method
+func (m_2 *MockFilterClient) UpdateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID string, m filter.Model, doSubmit bool, ifMatch string) (filter.Model, string, error) {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "UpdateBlueprint", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit, ifMatch)
+	ret0, _ := ret[0].(filter.Model)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UpdateBlueprint indicates an expected call of UpdateBlueprint
+func (mr *MockFilterClientMockRecorder) UpdateBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBlueprint", reflect.TypeOf((*MockFilterClient)(nil).UpdateBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, m, doSubmit, ifMatch)
+}
+
+// CreateBlueprint mocks base method
+func (m *MockFilterClient) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBlueprint", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateBlueprint indicates an expected call of CreateBlueprint
+func (mr *MockFilterClientMockRecorder) CreateBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names)
 }
 
 // GetPreview mocks base method
-func (m *MockFilterClient) GetPreview(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) (filter.Preview, error) {
+func (m *MockFilterClient) GetPreview(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (filter.Preview, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPreview", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "GetPreview", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
 	ret0, _ := ret[0].(filter.Preview)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPreview indicates an expected call of GetPreview
-func (mr *MockFilterClientMockRecorder) GetPreview(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockFilterClientMockRecorder) GetPreview(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreview", reflect.TypeOf((*MockFilterClient)(nil).GetPreview), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreview", reflect.TypeOf((*MockFilterClient)(nil).GetPreview), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
 }
 
 // MockDatasetClient is a mock of DatasetClient interface

--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -34,14 +34,14 @@ func (f Filter) Submit() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		fil, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		fil, eTag, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		mdl, err := f.FilterClient.UpdateBlueprint(req.Context(), userAccessToken, "", "", collectionID, fil, true)
+		mdl, _, err := f.FilterClient.UpdateBlueprint(req.Context(), userAccessToken, "", "", collectionID, fil, true, eTag)
 		if err != nil {
 			log.Event(ctx, "failed to submit filter blueprint", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -45,7 +45,7 @@ func (f *Filter) Search() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag0 != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
@@ -211,7 +211,7 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 			return
 		}
 
-		// TODO we might want to retry this handler if eTags don't match
+		// The user might want to retry this handler if eTags don't match
 		if eTag != eTag1 {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between get calls", log.ERROR, log.Error(err),

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -30,16 +31,25 @@ func (f *Filter) Search() http.HandlerFunc {
 			searchConfig = append(searchConfig, search.Config{InternalToken: f.SearchAPIAuthToken, FlorenceToken: req.Header.Get("X-Florence-Token")})
 		}
 
-		fil, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
+		fil, eTag0, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		selVals, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
+		selVals, eTag1, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
+			setStatusCode(req, w, err)
+			return
+		}
+
+		// TODO we might want to retry this handler if eTags don't match
+		if eTag0 != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "dimension": name, "e_tag_0": eTag0, "e_tag_1": eTag1})
 			setStatusCode(req, w, err)
 			return
 		}
@@ -137,7 +147,7 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 
 		redirectURI := fmt.Sprintf("/filters/%s/dimensions", filterID)
 
-		fil, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
+		fil, eTag, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -170,7 +180,8 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 			for _, item := range searchRes.Items {
 				options = append(options, item.Code)
 			}
-			if err := f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, options); err != nil {
+			_, err = f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, options, eTag)
+			if err != nil {
 				log.Event(ctx, "failed to add all dimension options", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 				setStatusCode(req, w, err)
 				return
@@ -183,7 +194,8 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 			for _, item := range searchRes.Items {
 				options = append(options, item.Code)
 			}
-			if err := f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, []string{}, options, f.BatchSize); err != nil {
+			_, err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, []string{}, options, f.BatchSize, eTag)
+			if err != nil {
 				log.Event(ctx, "failed to remove all dimension options, via patch", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 				setStatusCode(req, w, err)
 				return
@@ -192,9 +204,18 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 		}
 
 		// get all available dimension options from filter API
-		opts, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
+		opts, eTag1, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to retrieve dimension options", log.WARN, log.Error(err))
+			setStatusCode(req, w, err)
+			return
+		}
+
+		// TODO we might want to retry this handler if eTags don't match
+		if eTag != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between get calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "dimension": name, "e_tag_0": eTag, "e_tag_1": eTag1})
 			setStatusCode(req, w, err)
 			return
 		}
@@ -216,7 +237,7 @@ func (f *Filter) SearchUpdate() http.HandlerFunc {
 		addOptions = getOptionsAndRedirect(req.Form, &redirectURI)
 
 		// sent the PATCH with options to add and remove
-		err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, addOptions, removeOptions, f.BatchSize)
+		_, err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, name, addOptions, removeOptions, f.BatchSize, eTag1)
 		if err != nil {
 			log.Event(ctx, "failed to patch dimension values", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": name})
 			setStatusCode(req, w, err)

--- a/handlers/search_test.go
+++ b/handlers/search_test.go
@@ -95,9 +95,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetVersionDimensions(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version).Return(dataset.VersionDimensions{}, nil)
@@ -113,7 +113,7 @@ func TestUnitSearch(t *testing.T) {
 		})
 
 		Convey("Then search returns server error if GetJobState errors", func() {
-			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filter.Model{}, errors.New("get job state error"))
+			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filter.Model{}, "", errors.New("get job state error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -126,9 +126,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filter.DimensionOptions{}, errors.New("get dimensions options error"))
+				batchSize, maxWorkers).Return(filter.DimensionOptions{}, "", errors.New("get dimensions options error"))
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -141,9 +141,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filter.DimensionOptions{}, nil)
+				batchSize, maxWorkers).Return(filter.DimensionOptions{}, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, errors.New("dataset get error"))
 
 			w := callSearch()
@@ -157,9 +157,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filter.DimensionOptions{}, nil)
+				batchSize, maxWorkers).Return(filter.DimensionOptions{}, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, errors.New("get version error"))
 
@@ -174,9 +174,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptionsBatchProcess(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
@@ -192,9 +192,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptionsBatchProcess(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
@@ -212,9 +212,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets/abcde/editions/2017/versions/1",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(testSelectedOptions, nil)
+				batchSize, maxWorkers).Return(testSelectedOptions, testETag(0), nil)
 			mdc.EXPECT().Get(ctx, mockUserAuthToken, "", mockCollectionID, datasetID).Return(dataset.DatasetDetails{}, nil)
 			mdc.EXPECT().GetVersion(ctx, mockUserAuthToken, "", "", mockCollectionID, datasetID, edition, version).Return(dataset.Version{}, nil)
 			mdc.EXPECT().GetOptionsBatchProcess(ctx, mockUserAuthToken, "", mockCollectionID, datasetID, edition, version, name,
@@ -235,9 +235,9 @@ func TestUnitSearch(t *testing.T) {
 						HRef: "http://localhost:23200/v1/datasets",
 					},
 				},
-			}, nil)
+			}, testETag(0), nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filter.DimensionOptions{}, nil)
+				batchSize, maxWorkers).Return(filter.DimensionOptions{}, testETag(0), nil)
 
 			w := callSearch()
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -314,9 +314,9 @@ func TestSearchUpdate(t *testing.T) {
 				},
 			}
 			options := []string{"clothing-1", "clothing-2", "clothing-3"}
-			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(searchModel, nil)
-			mfc.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, ItemsEq(options)).Return(nil)
+			mfc.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, ItemsEq(options), testETag(0)).Return(testETag(1), nil)
 			formData := "q=clothing&cpih1dim1G30100=on&cpih1dim1G30200=on&save-and-return=Save+and+return&add-all=true"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusOK)
@@ -331,9 +331,9 @@ func TestSearchUpdate(t *testing.T) {
 				},
 			}
 			options := []string{"clothing-1", "clothing-2", "clothing-3"}
-			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(searchModel, nil)
-			mfc.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, []string{}, ItemsEq(options), batchSize).Return(nil)
+			mfc.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name, []string{}, ItemsEq(options), batchSize, testETag(0)).Return(testETag(1), nil)
 			formData := "q=clothing&cpih1dim1G30100=on&cpih1dim1G30200=on&save-and-return=Save+and+return&remove-all=true"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusOK)
@@ -363,22 +363,22 @@ func TestSearchUpdate(t *testing.T) {
 			}
 			expectedAddOptions := []string{"clothing-1", "clothing-2", "clothing-3"}
 			expectedRemoveOptions := []string{"clothing-4"}
-			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(searchModel, nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filterOptions, nil)
+				batchSize, maxWorkers).Return(filterOptions, testETag(0), nil)
 			mfc.EXPECT().PatchDimensionValues(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				ItemsEq(expectedAddOptions), ItemsEq(expectedRemoveOptions), batchSize).Return(nil)
+				ItemsEq(expectedAddOptions), ItemsEq(expectedRemoveOptions), batchSize, testETag(0)).Return(testETag(1), nil)
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusFound)
 		})
 
 		Convey("When GetDimensionOptions fails with a generic error, then the execution is aborted and an Internal Server Error is returned.", func() {
-			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, nil)
+			mfc.EXPECT().GetJobState(ctx, mockUserAuthToken, "", "", mockCollectionID, filterID).Return(filterModel, testETag(0), nil)
 			msc.EXPECT().Dimension(ctx, "cpih01", "time-series", "1", name, "clothing", expectedSearchClientConfigs).Return(&search.Model{}, nil)
 			mfc.EXPECT().GetDimensionOptionsInBatches(ctx, mockUserAuthToken, "", mockCollectionID, filterID, name,
-				batchSize, maxWorkers).Return(filter.DimensionOptions{}, errors.New("Error getting dimension options"))
+				batchSize, maxWorkers).Return(filter.DimensionOptions{}, "", errors.New("Error getting dimension options"))
 			formData := "q=clothing&clothing-1=on&clothing-2=on&clothing-3=on&save-and-return=Save+and+return"
 			w := callSearchUpdate(formData)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
 
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/dates"
@@ -30,13 +32,15 @@ func (f *Filter) UpdateTime() http.HandlerFunc {
 		ctx := req.Context()
 		dimensionName := "time"
 
-		if err := f.FilterClient.RemoveDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName); err != nil {
+		eTag, err := f.FilterClient.RemoveDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName, headers.IfMatchAnyETag)
+		if err != nil {
 			log.Event(ctx, "failed to remove dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		if err := f.FilterClient.AddDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName); err != nil {
+		eTag, err = f.FilterClient.AddDimension(ctx, userAccessToken, "", collectionID, filterID, dimensionName, eTag)
+		if err != nil {
 			log.Event(ctx, "failed to add dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
 			setStatusCode(req, w, err)
 			return
@@ -60,19 +64,23 @@ func (f *Filter) UpdateTime() http.HandlerFunc {
 
 		switch req.Form.Get("time-selection") {
 		case "latest":
-			if err := f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID, dimensionName, req.Form.Get("latest-option")); err != nil {
+			eTag, err = f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID, dimensionName, req.Form.Get("latest-option"), eTag)
+			if err != nil {
 				log.Event(ctx, "failed to add dimension value", log.ERROR, log.Error(err))
 			}
 		case "single":
-			if err := f.addSingleTime(filterID, userAccessToken, collectionID, req); err != nil {
+			eTag, err = f.addSingleTime(filterID, userAccessToken, collectionID, req, eTag)
+			if err != nil {
 				log.Event(ctx, "failed to add single time", log.ERROR, log.Error(err))
 			}
 		case "range":
-			if err := f.addTimeRange(filterID, userAccessToken, collectionID, req); err != nil {
+			eTag, err = f.addTimeRange(filterID, userAccessToken, collectionID, req, eTag)
+			if err != nil {
 				log.Event(ctx, "failed to add range of times", log.ERROR, log.Error(err))
 			}
 		case "list":
-			if err := f.addTimeList(filterID, userAccessToken, collectionID, req); err != nil {
+			eTag, err = f.addTimeList(filterID, userAccessToken, collectionID, req, eTag)
+			if err != nil {
 				log.Event(ctx, "failed to add list of times", log.ERROR, log.Error(err))
 			}
 		}
@@ -83,7 +91,7 @@ func (f *Filter) UpdateTime() http.HandlerFunc {
 
 }
 
-func (f *Filter) addSingleTime(filterID, userAccessToken, collectionID string, req *http.Request) error {
+func (f *Filter) addSingleTime(filterID, userAccessToken, collectionID string, req *http.Request, eTag string) (newETag string, err error) {
 	ctx := req.Context()
 
 	month := req.Form.Get("month-single")
@@ -92,14 +100,14 @@ func (f *Filter) addSingleTime(filterID, userAccessToken, collectionID string, r
 
 	date, err := time.Parse("January 2006", fmt.Sprintf("%s %s", month, year))
 	if err != nil {
-		return err
+		return eTag, err
 	}
 
-	return f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID, dimensionName, date.Format("Jan-06"))
+	return f.FilterClient.AddDimensionValue(ctx, userAccessToken, "", collectionID, filterID, dimensionName, date.Format("Jan-06"), eTag)
 }
 
 // addTimeList will save form time grouped list form data to the filter
-func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req *http.Request) error {
+func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req *http.Request, eTag string) (newETag string, err error) {
 	ctx := req.Context()
 	dimensionName := "time"
 
@@ -109,12 +117,12 @@ func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req
 	startYearInt, err := strconv.Atoi(startYearStr)
 	if err != nil {
 		log.Event(ctx, "failed to convert filter start year string to integer", log.ERROR, log.Error(err))
-		return err
+		return eTag, err
 	}
 	endYearInt, err := strconv.Atoi(endYearStr)
 	if err != nil {
 		log.Event(ctx, "failed to convert filter end year string to integer", log.ERROR, log.Error(err))
-		return err
+		return eTag, err
 	}
 
 	selectedMonths := req.Form["months"]
@@ -126,23 +134,22 @@ func (f *Filter) addTimeList(filterID, userAccessToken, collectionID string, req
 			monthYearComboTime, err := time.Parse("January 2006", monthYearComboStr)
 			if err != nil {
 				log.Event(ctx, "failed to convert filtered month and year combo to time format", log.ERROR, log.Error(err))
-				return err
+				return eTag, err
 			}
 			monthYearCombo := monthYearComboTime.Format("Jan-06")
 			options = append(options, monthYearCombo)
 		}
 	}
 
-	if err := f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, options); err != nil {
+	newETag, err = f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, options, eTag)
+	if err != nil {
 		log.Event(ctx, "failed to add dimension values", log.ERROR, log.Error(err))
-		return err
+		return eTag, err
 	}
-
-	// Should we not be returning error?
-	return nil
+	return newETag, nil
 }
 
-func (f *Filter) addTimeRange(filterID, userAccessToken, collectionID string, req *http.Request) error {
+func (f *Filter) addTimeRange(filterID, userAccessToken, collectionID string, req *http.Request, eTag string) (newETag string, err error) {
 	startMonth := req.Form.Get("start-month")
 	startYear := req.Form.Get("start-year")
 	endMonth := req.Form.Get("end-month")
@@ -152,27 +159,27 @@ func (f *Filter) addTimeRange(filterID, userAccessToken, collectionID string, re
 
 	values, labelIDMap, err := f.getDimensionValues(ctx, userAccessToken, collectionID, filterID, dimensionName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	dats, err := dates.ConvertToReadable(values)
 	if err != nil {
-		return err
+		return "", err
 	}
 	dats = dates.Sort(dats)
 
 	start, err := time.Parse("01 January 2006", fmt.Sprintf("01 %s %s", startMonth, startYear))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	end, err := time.Parse("01 January 2006", fmt.Sprintf("01 %s %s", endMonth, endYear))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if end.Before(start) {
-		return fmt.Errorf("start date: %s before end date: %s", start.String(), end.String())
+		return "", fmt.Errorf("start date: %s before end date: %s", start.String(), end.String())
 	}
 
 	values = dates.ConvertToCoded(dats)
@@ -183,7 +190,7 @@ func (f *Filter) addTimeRange(filterID, userAccessToken, collectionID string, re
 		}
 	}
 
-	return f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, options)
+	return f.FilterClient.SetDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, options, eTag)
 }
 
 // Time specifically handles the data for the time dimension page
@@ -194,7 +201,7 @@ func (f *Filter) Time() http.HandlerFunc {
 		ctx := req.Context()
 		dimensionName := "time"
 
-		fj, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
+		fj, eTag0, err := f.FilterClient.GetJobState(ctx, userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -252,9 +259,18 @@ func (f *Filter) Time() http.HandlerFunc {
 			return
 		}
 
-		selValues, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, dimensionName, f.BatchSize, f.BatchMaxWorkers)
+		selValues, eTag1, err := f.FilterClient.GetDimensionOptionsInBatches(ctx, userAccessToken, "", collectionID, filterID, dimensionName, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			log.Event(ctx, "failed to get options from filter client", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dimensionName})
+			setStatusCode(req, w, err)
+			return
+		}
+
+		if eTag0 != eTag1 {
+			err := errors.New("inconsistent filter data")
+			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
+				log.Data{"filter_id": filterID, "e_tag_0": eTag0, "e_tag_1": eTag1})
+			// TODO we might want to retry this handler in this case?
 			setStatusCode(req, w, err)
 			return
 		}

--- a/handlers/time.go
+++ b/handlers/time.go
@@ -270,7 +270,7 @@ func (f *Filter) Time() http.HandlerFunc {
 			err := errors.New("inconsistent filter data")
 			log.Event(ctx, "data consistency cannot be guaranteed because filter was modified between calls", log.ERROR, log.Error(err),
 				log.Data{"filter_id": filterID, "e_tag_0": eTag0, "e_tag_1": eTag1})
-			// TODO we might want to retry this handler in this case?
+			// The user might want to retry this handler in this case
 			setStatusCode(req, w, err)
 			return
 		}

--- a/handlers/time_test.go
+++ b/handlers/time_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/golang/mock/gomock"
@@ -52,9 +53,9 @@ func TestUpdateTime(t *testing.T) {
 	Convey("Given that a user has selected time options via the list time-selection, then the redirect is successful and the expected calls are made to filter API", t, func() {
 		options := []string{"Aug-11", "Aug-12"}
 		mockClient := NewMockFilterClient(mockCtrl)
-		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", options).Return(nil)
+		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", headers.IfMatchAnyETag).Return(testETag(0), nil)
+		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", testETag(0)).Return(testETag(1), nil)
+		mockClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", options, testETag(1)).Return(testETag(2), nil)
 		formData := "latest-option=Nov-17&latest-month=November&latest-year=2017&month-single=Select&year-single=Select&start-month=Select&start-year=Select&end-month=Select&end-year=Select&time-selection=list&months=August&start-year-grouped=2011&end-year-grouped=2012&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockClient, nil)
 		So(w.Code, ShouldEqual, 302)
@@ -63,9 +64,9 @@ func TestUpdateTime(t *testing.T) {
 	Convey("Given that a user has slected the latest time option, then the redirect is successful and the expected calls are made to Filter API", t, func() {
 		option := "Jul-20"
 		mockClient := NewMockFilterClient(mockCtrl)
-		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().AddDimensionValue(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", option).Return(nil)
+		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", headers.IfMatchAnyETag).Return(testETag(0), nil)
+		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", testETag(0)).Return(testETag(1), nil)
+		mockClient.EXPECT().AddDimensionValue(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", option, testETag(1)).Return(testETag(2), nil)
 		formData := "time-selection=latest&latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&month-single=Select&year-single=Select&start-month=Select&start-year=Select&end-month=Select&end-year=Select&months=February&start-year-grouped=2000&end-year-grouped=2002&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockClient, nil)
 		So(w.Code, ShouldEqual, 302)
@@ -74,9 +75,9 @@ func TestUpdateTime(t *testing.T) {
 	Convey("Given that a user has selected a time option via the single selection, then the redirect is successful and the expected calls are made to Filter API", t, func() {
 		option := "May-19"
 		mockClient := NewMockFilterClient(mockCtrl)
-		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockClient.EXPECT().AddDimensionValue(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", option).Return(nil)
+		mockClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", headers.IfMatchAnyETag).Return(testETag(0), nil)
+		mockClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", testETag(0)).Return(testETag(1), nil)
+		mockClient.EXPECT().AddDimensionValue(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", option, testETag(1)).Return(testETag(2), nil)
 		formData := "latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&time-selection=single&month-single=May&year-single=2019&start-month=Select&start-year=Select&end-month=Select&end-year=Select&start-year-grouped=Select&end-year-grouped=Select&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockClient, nil)
 		So(w.Code, ShouldEqual, 302)
@@ -100,12 +101,12 @@ func TestUpdateTime(t *testing.T) {
 		filterOptions := []string{"Jan-00", "Feb-00", "Mar-00"}
 		mockFilterClient := NewMockFilterClient(mockCtrl)
 		mockDatasetClient := NewMockDatasetClient(mockCtrl)
-		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time").Return(nil)
-		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, nil)
+		mockFilterClient.EXPECT().RemoveDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", headers.IfMatchAnyETag).Return(testETag(0), nil)
+		mockFilterClient.EXPECT().AddDimension(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", testETag(0)).Return(testETag(1), nil)
+		mockFilterClient.EXPECT().GetJobState(ctx, mockUserAuthToken, mockServiceAuthToken, "", mockCollectionID, mockFilterID).Return(expectedFilterModel, testETag(1), nil)
 		mockDatasetClient.EXPECT().GetOptionsInBatches(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, "abcde", "2017", "1", "time",
 			batchSize, maxWorkers).Return(datasetOptions, nil)
-		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", filterOptions).Return(nil)
+		mockFilterClient.EXPECT().SetDimensionValues(ctx, mockUserAuthToken, mockServiceAuthToken, mockCollectionID, mockFilterID, "time", filterOptions, testETag(1)).Return(testETag(2), nil)
 		formData := "latest-option=Jul-20&latest-month=July&latest-year=2020&first-year=1988&first-month=January&month-single=Select&year-single=Select&time-selection=range&start-month=January&start-year=2000&end-month=March&end-year=2000&start-year-grouped=Select&end-year-grouped=Select&save-and-return=Save+and+return"
 		w := callTimeUpdate(formData, mockFilterClient, mockDatasetClient)
 		So(w.Code, ShouldEqual, 302)

--- a/handlers/update-version.go
+++ b/handlers/update-version.go
@@ -23,14 +23,14 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
-		oldJob, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
+		oldJob, _, err := f.FilterClient.GetJobState(req.Context(), userAccessToken, "", "", collectionID, filterID)
 		if err != nil {
 			log.Event(ctx, "failed to get job state", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
 			return
 		}
 
-		dims, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, filter.QueryParams{})
+		dims, _, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, filter.QueryParams{})
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
 			setStatusCode(req, w, err)
@@ -59,7 +59,7 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 			return
 		}
 
-		newFilterID, err := f.FilterClient.CreateBlueprint(req.Context(), userAccessToken, "", "", collectionID, datasetID, edition, string(editionDetails.Links.LatestVersion.ID), []string{})
+		newFilterID, newFilterETag, err := f.FilterClient.CreateBlueprint(req.Context(), userAccessToken, "", "", collectionID, datasetID, edition, string(editionDetails.Links.LatestVersion.ID), []string{})
 		if err != nil {
 			log.Event(ctx, "failed to create filter blueprint", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID, "edition": edition, "version": editionDetails.Links.LatestVersion.ID})
 			setStatusCode(req, w, err)
@@ -69,17 +69,19 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 		for _, dim := range dims.Items {
 
 			// Copy dimension to new filter
-			if err := f.FilterClient.AddDimension(req.Context(), userAccessToken, "", collectionID, newFilterID, dim.Name); err != nil {
+			newFilterETag, err = f.FilterClient.AddDimension(req.Context(), userAccessToken, "", collectionID, newFilterID, dim.Name, newFilterETag)
+			if err != nil {
 				log.Event(ctx, "failed to add dimension", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)
 				return
 			}
 
 			// Copy each batch of options to the new filter dimension via PATCH operations.
-			processBatch := f.batchAddOptions(req.Context(), userAccessToken, collectionID, newFilterID, dim.Name)
+			processBatch := f.batchAddOptions(req.Context(), userAccessToken, collectionID, newFilterID, dim.Name, newFilterETag)
 
 			// Call filter API GetOptions in batches and aggregate the responses
-			if err := f.FilterClient.GetDimensionOptionsBatchProcess(req.Context(), userAccessToken, "", collectionID, filterID, dim.Name, processBatch, f.BatchSize, f.BatchMaxWorkers); err != nil {
+			newFilterETag, err = f.FilterClient.GetDimensionOptionsBatchProcess(req.Context(), userAccessToken, "", collectionID, filterID, dim.Name, processBatch, f.BatchSize, f.BatchMaxWorkers, true)
+			if err != nil {
 				log.Event(ctx, "failed to get and process options from filter client in batches", log.ERROR, log.Error(err), log.Data{"filter_id": filterID, "dimension": dim.Name})
 				setStatusCode(req, w, err)
 				return
@@ -93,12 +95,14 @@ func (f *Filter) UseLatest() http.HandlerFunc {
 }
 
 // batchAddOptions generates a batch processor to add the dimension options for each provided batch to filter API, by calling the patch endpoint.
-func (f *Filter) batchAddOptions(ctx context.Context, userAccessToken, collectionID, filterID, dimensionName string) filter.DimensionOptionsBatchProcessor {
-	return func(batch filter.DimensionOptions) (forceAbort bool, err error) {
+func (f *Filter) batchAddOptions(ctx context.Context, userAccessToken, collectionID, filterID, dimensionName, initialETag string) filter.DimensionOptionsBatchProcessor {
+	currentETag := initialETag
+	return func(batch filter.DimensionOptions, oldFilterETag string) (forceAbort bool, err error) {
 		var vals []string
 		for _, val := range batch.Items {
 			vals = append(vals, val.Option)
 		}
-		return false, f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, vals, []string{}, f.BatchSize)
+		currentETag, err = f.FilterClient.PatchDimensionValues(ctx, userAccessToken, "", collectionID, filterID, dimensionName, vals, []string{}, f.BatchSize, currentETag)
+		return false, err
 	}
 }


### PR DESCRIPTION
### What

- Upgraded to latest dp-api-clients-go to incorporate eTag/If-Match for filter api calls
- Updated interface, calls and tests. New possible errors are introduced for data inconsistency.
- Note: this change will introduce new possible failure scenarios. If there is a race condition for a filter in filter API, a call may fail with 409 status.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Note: I tested a filer journey locally with Filter API, frontend-dataset-controller and frontend-filter-dataset-controller using eTags, and it was successful (regression test successful).

### Who can review

Anyone