### PR TITLE
used batch processing for metadata file generation

### DIFF
--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -24,9 +24,6 @@ import (
 // maxMetadataOptions is the maximum number of options per dimension for which the metadata.txt file size will be calculated
 const maxMetadataOptions = 1000
 
-// errTooManyOptions is an error returned when a request can't complete because the dimension has too many options
-var errTooManyOptions = errors.New("too many options in dimension")
-
 // Submit handles the submitting of a filter job through the filter API
 func (f Filter) Submit() http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
@@ -193,12 +190,9 @@ func (f *Filter) OutputPage() http.HandlerFunc {
 		// is currently being called by f.getMetadataTextSize and the for loop below
 		size, err := f.getMetadataTextSize(req.Context(), userAccessToken, collectionID, datasetID, edition, version, metadata, dims)
 		if err != nil {
-			if err != errTooManyOptions {
-				log.Event(ctx, "failed to get metadata text size", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
-				setStatusCode(req, w, err)
-				return
-			}
-			log.Event(ctx, "failed to get metadata text size because at least a dimension has too many options", log.WARN, log.Data{"dataset_id": datasetID, "edition": edition, "version": version, "max_metadata_options": maxMetadataOptions})
+			log.Event(ctx, "failed to get metadata text size", log.ERROR, log.Error(err), log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
+			setStatusCode(req, w, err)
+			return
 		}
 
 		// count number of options for each dimension in dataset API to check if any dimension has a single option
@@ -322,13 +316,9 @@ func (f *Filter) getMetadataTextSize(ctx context.Context, userAccessToken, colle
 	b.WriteString("Dimensions:\n")
 
 	for _, dimension := range dimensions.Items {
-		q := dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}
-		options, err := f.DatasetClient.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, q)
+		options, err := f.DatasetClient.GetOptionsInBatches(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, f.BatchSize, f.BatchMaxWorkers)
 		if err != nil {
 			return 0, err
-		}
-		if options.TotalCount > maxMetadataOptions {
-			return 0, errTooManyOptions
 		}
 
 		b.WriteString(options.String())


### PR DESCRIPTION
### What

After testing the metadata file generation 'on-the-fly' with >200,000 options per dimension, I didn't see a huge performance impact. In this task the metadata file size calculation is reintroduced using get options in batches

- Get options from dataset API in batches
- Removed errTooManyOptions error

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Information: I tested it locally by artificially returning 200,000 options per dimension for CPIH datasets. The file was around 16MB.

### Who can review

anyone