### PR TITLE
removed ordering for non-hierarchical dimensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-dataset-controller
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51
+	github.com/ONSdigital/dp-api-clients-go v1.34.4
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/ONSdigital/dp-frontend-filter-dataset-controller
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.33.3
+	github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-net v1.0.10
+	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/go-ns v0.0.0-20200511161740-afc39066ee62
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.29.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.33.3 h1:Qa38jlMWEdgKeSt7tLhcctHfAFtTMn70ARMpCIP5kUs=
-github.com/ONSdigital/dp-api-clients-go v1.33.3/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51 h1:PEg+rr+7R+M/erDSsLRjSrJuXAhxgYkmgldYUkmv+4Q=
+github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0 h1:jMM5drrwcOK5H0DTL8JpLOZm2rw+VJrz+vI9h2GQ8nQ=
@@ -23,8 +23,8 @@ github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZ
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
 github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihlzIWDrQ/gc=
 github.com/ONSdigital/dp-net v1.0.9/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
-github.com/ONSdigital/dp-net v1.0.10 h1:jtliifmkyRsDlp+pC5pYt9BEHF+DqaoJyTcOuLjA/yk=
-github.com/ONSdigital/dp-net v1.0.10/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
+github.com/ONSdigital/dp-net v1.0.12 h1:Vd06ia1FXKR9uyhzWykQ52b1LTp4N0VOLnrF7KOeP78=
+github.com/ONSdigital/dp-net v1.0.12/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
@@ -41,12 +41,10 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 h1:yswqe8UdKNWn4kjh1YTaAbvOSPeg95xhW7h4qeICL5E=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -97,7 +95,6 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/unrolled/render v1.0.2/go.mod h1:gN9T0NhL4Bfbwu8ann7Ry/TGHYfosul+J0obPf6NBdM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -133,7 +130,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.29.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51 h1:PEg+rr+7R+M/erDSsLRjSrJuXAhxgYkmgldYUkmv+4Q=
-github.com/ONSdigital/dp-api-clients-go v1.34.4-0.20210427161009-ad102fe8ab51/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go v1.34.4 h1:SHdhxHxflgoAesWpwrVR0OQz+pLKI4jMl58mZrzKyA4=
+github.com/ONSdigital/dp-api-clients-go v1.34.4/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0 h1:jMM5drrwcOK5H0DTL8JpLOZm2rw+VJrz+vI9h2GQ8nQ=

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -22,13 +22,13 @@ import (
 
 // codes for geography nodes that need to be flattened in a single layer
 const (
-	uk              = "K02000001"
-	greatBritain    = "K03000001"
-	englandAndWales = "K04000001"
-	england         = "E92000001"
-	northernIreland = "N92000002"
-	scotland        = "S92000003"
-	wales           = "W92000004"
+	Uk              = "K02000001"
+	GreatBritain    = "K03000001"
+	EnglandAndWales = "K04000001"
+	England         = "E92000001"
+	NorthernIreland = "N92000002"
+	Scotland        = "S92000003"
+	Wales           = "W92000004"
 )
 
 // HierarchyUpdate controls the updating of a hierarchy job
@@ -333,7 +333,7 @@ func (n flatNodes) addWithChildren(val hierarchy.Child, i int) {
 	}
 }
 
-// hasOrder returns true iif all child items in the list have a non-nil order value
+// hasOrder returns true if and only if all child items in the list have a non-nil order values
 func (n flatNodes) hasOrder() bool {
 	for _, child := range n.list {
 		if child.Order == nil {
@@ -376,22 +376,22 @@ func (f *Filter) flattenGeographyTopLevel(ctx context.Context, instanceID string
 	// create nodes struct with default order
 	nodes := flatNodes{
 		list:         make([]*hierarchy.Child, 6),
-		defaultOrder: map[string]int{greatBritain: 0, englandAndWales: 1, england: 2, northernIreland: 3, scotland: 4, wales: 5},
+		defaultOrder: map[string]int{GreatBritain: 0, EnglandAndWales: 1, England: 2, NorthernIreland: 3, Scotland: 4, Wales: 5},
 	}
 
 	// add items to flatNodes according to defaultOrder
 	for _, val := range root.Children {
-		if val.Links.Code.ID == greatBritain {
-			nodes.addWithoutChildren(val, nodes.defaultOrder[greatBritain])
+		if val.Links.Code.ID == GreatBritain {
+			nodes.addWithoutChildren(val, nodes.defaultOrder[GreatBritain])
 
-			child, err := f.HierarchyClient.GetChild(ctx, instanceID, "geography", greatBritain)
+			child, err := f.HierarchyClient.GetChild(ctx, instanceID, "geography", GreatBritain)
 			if err != nil {
 				return h, err
 			}
 
 			for _, childVal := range child.Children {
-				if childVal.Links.Code.ID == englandAndWales {
-					nodes.addWithoutChildren(childVal, nodes.defaultOrder[englandAndWales])
+				if childVal.Links.Code.ID == EnglandAndWales {
+					nodes.addWithoutChildren(childVal, nodes.defaultOrder[EnglandAndWales])
 
 					grandChild, err := f.HierarchyClient.GetChild(ctx, instanceID, "geography", childVal.Links.Code.ID)
 					if err != nil {
@@ -399,24 +399,24 @@ func (f *Filter) flattenGeographyTopLevel(ctx context.Context, instanceID string
 					}
 
 					for _, grandChildVal := range grandChild.Children {
-						if grandChildVal.Links.Code.ID == england {
-							nodes.addWithChildren(grandChildVal, nodes.defaultOrder[england])
+						if grandChildVal.Links.Code.ID == England {
+							nodes.addWithChildren(grandChildVal, nodes.defaultOrder[England])
 						}
 
-						if grandChildVal.Links.Code.ID == wales {
-							nodes.addWithChildren(grandChildVal, nodes.defaultOrder[wales])
+						if grandChildVal.Links.Code.ID == Wales {
+							nodes.addWithChildren(grandChildVal, nodes.defaultOrder[Wales])
 						}
 					}
 				}
 
-				if childVal.Links.Code.ID == scotland {
-					nodes.addWithChildren(childVal, nodes.defaultOrder[scotland])
+				if childVal.Links.Code.ID == Scotland {
+					nodes.addWithChildren(childVal, nodes.defaultOrder[Scotland])
 				}
 			}
 		}
 
-		if val.Links.Code.ID == northernIreland {
-			nodes.addWithChildren(val, nodes.defaultOrder[northernIreland])
+		if val.Links.Code.ID == NorthernIreland {
+			nodes.addWithChildren(val, nodes.defaultOrder[NorthernIreland])
 		}
 	}
 

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -385,7 +385,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chWales := hierarchy.Child{
 			Label: "Wales",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: wales},
+				Code: hierarchy.Link{ID: Wales},
 			},
 			HasData: true,
 			Order:   &order0,
@@ -394,7 +394,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chEngland := hierarchy.Child{
 			Label: "England",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: england},
+				Code: hierarchy.Link{ID: England},
 			},
 			HasData: true,
 			Order:   &order1,
@@ -403,7 +403,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chNorthernIreland := hierarchy.Child{
 			Label: "Northern Ireland",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: northernIreland},
+				Code: hierarchy.Link{ID: NorthernIreland},
 			},
 			HasData: true,
 			Order:   &order2,
@@ -412,7 +412,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chScotland := hierarchy.Child{
 			Label: "Scotland",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: scotland},
+				Code: hierarchy.Link{ID: Scotland},
 			},
 			HasData: true,
 			Order:   &order3,
@@ -421,7 +421,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chGreatBritain := hierarchy.Child{
 			Label: "Great Britain",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: greatBritain},
+				Code: hierarchy.Link{ID: GreatBritain},
 			},
 			HasData: true,
 			Order:   &order4,
@@ -430,7 +430,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		chEnglandAndWales := hierarchy.Child{
 			Label: "England and Wales",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: englandAndWales},
+				Code: hierarchy.Link{ID: EnglandAndWales},
 			},
 			HasData: true,
 			Order:   &order5,
@@ -439,7 +439,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		testUK := hierarchy.Model{
 			Label: "United Kingdom",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: uk},
+				Code: hierarchy.Link{ID: Uk},
 			},
 			HasData:          true,
 			NumberofChildren: 2,
@@ -449,7 +449,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		testGB := hierarchy.Model{
 			Label: "Great Britain",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: greatBritain},
+				Code: hierarchy.Link{ID: GreatBritain},
 			},
 			HasData:          true,
 			Order:            &order4,
@@ -460,7 +460,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		testEnglandAndWales := hierarchy.Model{
 			Label: "England and Wales",
 			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: englandAndWales},
+				Code: hierarchy.Link{ID: EnglandAndWales},
 			},
 			HasData:          true,
 			Order:            &order5,
@@ -471,8 +471,8 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		Convey("And a successful hierarchy client mock where all models contain order", func() {
 			mockHierarchyClient := NewMockHierarchyClient(mockCtrl)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, expectedDimensionName).Return(testUK, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, greatBritain).Return(testGB, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, englandAndWales).Return(testEnglandAndWales, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, GreatBritain).Return(testGB, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, EnglandAndWales).Return(testEnglandAndWales, nil)
 			f := NewFilter(nil, nil, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
 
 			Convey("then flattenGeographyTopLevel returns a flat list of geography nodes sorted in the order defined by the children order property", func() {
@@ -480,7 +480,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 					Label:   "United Kingdom",
 					HasData: true,
 					Links: hierarchy.Links{
-						Code: hierarchy.Link{ID: uk},
+						Code: hierarchy.Link{ID: Uk},
 					},
 					Children: []hierarchy.Child{chWales, chEngland, chNorthernIreland, chScotland, chGreatBritain, chEnglandAndWales},
 				}
@@ -492,12 +492,16 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 		})
 
 		Convey("And a successful hierarchy client mock where some models don't contain order", func() {
+			// expected without order
 			chScotland.Order = nil
+
+			// mock hierarchy response without order
 			testGB.Children[0].Order = nil
+
 			mockHierarchyClient := NewMockHierarchyClient(mockCtrl)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, expectedDimensionName).Return(testUK, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, greatBritain).Return(testGB, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, englandAndWales).Return(testEnglandAndWales, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, GreatBritain).Return(testGB, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, EnglandAndWales).Return(testEnglandAndWales, nil)
 			f := NewFilter(nil, nil, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
 
 			Convey("then flattenGeographyTopLevel returns a flat list of geography nodes sorted according to the default hardcoded order", func() {
@@ -505,7 +509,49 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 					Label:   "United Kingdom",
 					HasData: true,
 					Links: hierarchy.Links{
-						Code: hierarchy.Link{ID: uk},
+						Code: hierarchy.Link{ID: Uk},
+					},
+					Children: []hierarchy.Child{chGreatBritain, chEnglandAndWales, chEngland, chNorthernIreland, chScotland, chWales},
+				}
+
+				h, err := f.flattenGeographyTopLevel(ctx, testInstanceID)
+				So(err, ShouldBeNil)
+				So(h, ShouldResemble, expectedFlatGeography)
+			})
+		})
+
+		Convey("And a successful hierarchy client mock where none of the models contain order", func() {
+			// expected without order
+			chWales.Order = nil
+			chEngland.Order = nil
+			chNorthernIreland.Order = nil
+			chScotland.Order = nil
+			chGreatBritain.Order = nil
+			chEnglandAndWales.Order = nil
+
+			// mock hierarchy response without order
+			testUK.Order = nil
+			testUK.Children[0].Order = nil
+			testUK.Children[1].Order = nil
+			testGB.Order = nil
+			testGB.Children[0].Order = nil
+			testGB.Children[1].Order = nil
+			testEnglandAndWales.Order = nil
+			testEnglandAndWales.Children[0].Order = nil
+			testEnglandAndWales.Children[1].Order = nil
+
+			mockHierarchyClient := NewMockHierarchyClient(mockCtrl)
+			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, expectedDimensionName).Return(testUK, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, GreatBritain).Return(testGB, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, EnglandAndWales).Return(testEnglandAndWales, nil)
+			f := NewFilter(nil, nil, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
+
+			Convey("then flattenGeographyTopLevel returns a flat list of geography nodes sorted according to the default hardcoded order", func() {
+				expectedFlatGeography := hierarchy.Model{
+					Label:   "United Kingdom",
+					HasData: true,
+					Links: hierarchy.Links{
+						Code: hierarchy.Link{ID: Uk},
 					},
 					Children: []hierarchy.Child{chGreatBritain, chEnglandAndWales, chEngland, chNorthernIreland, chScotland, chWales},
 				}
@@ -532,7 +578,7 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 			testErr := errors.New("testError")
 			mockHierarchyClient := NewMockHierarchyClient(mockCtrl)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, expectedDimensionName).Return(testUK, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, greatBritain).Return(hierarchy.Model{}, testErr)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, GreatBritain).Return(hierarchy.Model{}, testErr)
 			f := NewFilter(nil, nil, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
 
 			Convey("then flattenGeographyTopLevel fails with the same error and no other call is performed", func() {
@@ -545,115 +591,13 @@ func TestFlattenGeographyTopLevel(t *testing.T) {
 			testErr := errors.New("testError")
 			mockHierarchyClient := NewMockHierarchyClient(mockCtrl)
 			mockHierarchyClient.EXPECT().GetRoot(ctx, testInstanceID, expectedDimensionName).Return(testUK, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, greatBritain).Return(testGB, nil)
-			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, englandAndWales).Return(hierarchy.Model{}, testErr)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, GreatBritain).Return(testGB, nil)
+			mockHierarchyClient.EXPECT().GetChild(ctx, testInstanceID, expectedDimensionName, EnglandAndWales).Return(hierarchy.Model{}, testErr)
 			f := NewFilter(nil, nil, nil, mockHierarchyClient, nil, nil, "/v1", cfg)
 
 			Convey("then flattenGeographyTopLevel fails with the same error and no other call is performed", func() {
 				_, err := f.flattenGeographyTopLevel(ctx, testInstanceID)
 				So(err, ShouldResemble, testErr)
-			})
-		})
-	})
-}
-
-func TestFlatNodes(t *testing.T) {
-
-	Convey("Given mocked hierarchy Child items", t, func() {
-
-		chWales := &hierarchy.Child{
-			Label: "Wales",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: wales},
-			},
-		}
-
-		chEngland := &hierarchy.Child{
-			Label: "England",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: england},
-			},
-		}
-
-		chNorthernIreland := &hierarchy.Child{
-			Label: "Northern Ireland",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: northernIreland},
-			},
-		}
-
-		chScotland := &hierarchy.Child{
-			Label: "Scotland",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: scotland},
-			},
-		}
-
-		chGreatBritain := &hierarchy.Child{
-			Label: "Great Britain",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: greatBritain},
-			},
-		}
-
-		chEnglandAndWales := &hierarchy.Child{
-			Label: "England and Wales",
-			Links: hierarchy.Links{
-				Code: hierarchy.Link{ID: englandAndWales},
-			},
-		}
-
-		order0 := 0
-		order1 := 10
-		order2 := 25
-		order3 := 38
-		order4 := 41
-		order5 := 52
-
-		Convey("And a fully populated flatNodes structure without children-defined order", func() {
-			f := flatNodes{
-				list:         []*hierarchy.Child{chWales, chEngland, chNorthernIreland, chScotland, chGreatBritain, chEnglandAndWales},
-				defaultOrder: map[string]int{greatBritain: 0, englandAndWales: 1, england: 2, northernIreland: 3, scotland: 4, wales: 5},
-			}
-
-			Convey("Then when sort is called the items are sorted incrementally according to the default order", func() {
-				f.sort()
-				So(f.list, ShouldResemble, []*hierarchy.Child{chGreatBritain, chEnglandAndWales, chEngland, chNorthernIreland, chScotland, chWales})
-			})
-		})
-
-		Convey("And a fully populated flatNodes structure where all but children contain order", func() {
-			chNorthernIreland.Order = &order0
-			chScotland.Order = &order1
-			chEngland.Order = &order2
-			chGreatBritain.Order = &order3
-			chWales.Order = &order4
-			chEnglandAndWales.Order = &order5
-			f := flatNodes{
-				list:         []*hierarchy.Child{chWales, chEngland, chNorthernIreland, chScotland, chGreatBritain, chEnglandAndWales},
-				defaultOrder: map[string]int{greatBritain: 0, englandAndWales: 1, england: 2, northernIreland: 3, scotland: 4, wales: 5},
-			}
-
-			Convey("Then when sort is called the items are sorted incrementally according to the child items order", func() {
-				f.sort()
-				So(f.list, ShouldResemble, []*hierarchy.Child{chNorthernIreland, chScotland, chEngland, chGreatBritain, chWales, chEnglandAndWales})
-			})
-		})
-
-		Convey("And a fully populated flatNodes structure where all but one children contain order", func() {
-			chNorthernIreland.Order = &order0
-			chScotland.Order = &order1
-			chEngland.Order = &order2
-			chGreatBritain.Order = &order3
-			chWales.Order = &order4
-			f := flatNodes{
-				list:         []*hierarchy.Child{chWales, chEngland, chNorthernIreland, chScotland, chGreatBritain, chEnglandAndWales},
-				defaultOrder: map[string]int{greatBritain: 0, englandAndWales: 1, england: 2, northernIreland: 3, scotland: 4, wales: 5},
-			}
-
-			Convey("Then when sort is called the items are sorted incrementally according to the default order", func() {
-				f.sort()
-				So(f.list, ShouldResemble, []*hierarchy.Child{chGreatBritain, chEnglandAndWales, chEngland, chNorthernIreland, chScotland, chWales})
 			})
 		})
 	})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -81,7 +80,6 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 				fod.AddedCategories = append(fod.AddedCategories, d.Values...)
 			}
 
-			times = dates.Sort(times)
 			for _, time := range times {
 				fod.AddedCategories = append(fod.AddedCategories, time.Format("January 2006"))
 			}
@@ -94,23 +92,6 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 					if len(dim.Label) > 0 {
 						fod.Filter = dim.Label
 					}
-				}
-			}
-
-			if d.Name == "age" {
-				var ages []int
-				for _, a := range fod.AddedCategories {
-					age, err := strconv.Atoi(a)
-					if err != nil {
-						continue
-					}
-
-					ages = append(ages, age)
-				}
-
-				sort.Ints(ages)
-				for i, age := range ages {
-					fod.AddedCategories[i] = strconv.Itoa(age)
 				}
 			}
 		}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/filter"
@@ -410,8 +411,28 @@ func getTestDimensions() []filter.ModelDimension {
 	}
 }
 
+// getTestDatasetTimeOptions returns 3 dataset Options for the time dimension, sorted in a non-chronological order
 func getTestDatasetTimeOptions() dataset.Options {
 	return dataset.Options{Items: []dataset.Option{
+		{
+			DimensionID: "time",
+			Label:       "Apr-07",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
+					ID:  "mmm-yy",
+				},
+				Version: dataset.Link{
+					URL: "http://api.localhost:23200/v1/datasets/cpih01/editions/time-series/versions/7",
+					ID:  "7",
+				},
+				Code: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy/codes/Month",
+					ID:  "Month",
+				},
+			},
+			Option: "Apr-07",
+		},
 		{
 			DimensionID: "time",
 			Label:       "Apr-05",
@@ -452,7 +473,7 @@ func getTestDatasetTimeOptions() dataset.Options {
 		},
 		{
 			DimensionID: "time",
-			Label:       "Apr-07",
+			Label:       "Jun-05",
 			Links: dataset.Links{
 				CodeList: dataset.Link{
 					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
@@ -467,8 +488,28 @@ func getTestDatasetTimeOptions() dataset.Options {
 					ID:  "Month",
 				},
 			},
-			Option: "Apr-07",
-		}}}
+			Option: "Jun-05",
+		},
+		{
+			DimensionID: "time",
+			Label:       "May-05",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy",
+					ID:  "mmm-yy",
+				},
+				Version: dataset.Link{
+					URL: "http://api.localhost:23200/v1/datasets/cpih01/editions/time-series/versions/7",
+					ID:  "7",
+				},
+				Code: dataset.Link{
+					URL: "http://api.localhost:23200/v1/code-lists/mmm-yy/codes/Month",
+					ID:  "Month",
+				},
+			},
+			Option: "May-05",
+		},
+	}}
 }
 
 func getTestDatasetDimensions() []dataset.VersionDimension {
@@ -663,99 +704,383 @@ func TestCreateHierarchyPage(t *testing.T) {
 	})
 }
 
-func TestCreateTimePage(t *testing.T) {
-	Convey("maps filter to page model correctly", t, func() {
-		desiredPageModel := timeModel.Page{
-			Page: model.Page{},
-			Data: timeModel.Data{
-				LatestTime:         timeModel.Value{},
-				FirstTime:          timeModel.Value{},
-				Values:             nil,
-				Months:             []string{"Select", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
-				Years:              []string{"Select", "2005", "2006", "2007"},
-				CheckedRadio:       "",
-				FormAction:         timeModel.Link{},
-				SelectedStartMonth: "",
-				SelectedStartYear:  "",
-				SelectedEndMonth:   "",
-				SelectedEndYear:    "",
-				Type:               "",
-				DatasetTitle:       "",
-				GroupedSelection: timeModel.GroupedSelection{
-					Months: []timeModel.Month{
-						{
-							Name:       "January",
-							IsSelected: false,
-						},
-						{
-							Name:       "February",
-							IsSelected: false,
-						},
-						{
-							Name:       "March",
-							IsSelected: false,
-						},
-						{
-							Name:       "April",
-							IsSelected: false,
-						},
-						{
-							Name:       "May",
-							IsSelected: false,
-						},
-						{
-							Name:       "June",
-							IsSelected: false,
-						},
-						{
-							Name:       "July",
-							IsSelected: false,
-						},
-						{
-							Name:       "August",
-							IsSelected: false,
-						},
-						{
-							Name:       "September",
-							IsSelected: false,
-						},
-						{
-							Name:       "October",
-							IsSelected: false,
-						},
-						{
-							Name:       "November",
-							IsSelected: false,
-						},
-						{
-							Name:       "December",
-							IsSelected: false,
-						},
+// getExpectedTimePage returns the timeModel.Page model that would be generated
+// from the options returned by getTestDatasetTimeOptions and no selected options, keeping the original values order
+func getExpectedTimePage(datasetID, filterID, lang string) timeModel.Page {
+	p := timeModel.Page{
+		Page: model.Page{},
+		Data: timeModel.Data{
+			LatestTime: timeModel.Value{
+				Month:      "April",
+				Year:       "2007",
+				Option:     "Apr-07",
+				IsSelected: false,
+			},
+			FirstTime: timeModel.Value{
+				Month:      "April",
+				Year:       "2005",
+				Option:     "Apr-05",
+				IsSelected: false,
+			},
+			Values: []timeModel.Value{
+				{Month: "April", Year: "2007", Option: "Apr-07", IsSelected: false},
+				{Month: "April", Year: "2005", Option: "Apr-05", IsSelected: false},
+				{Month: "April", Year: "2006", Option: "Apr-06", IsSelected: false},
+				{Month: "June", Year: "2005", Option: "Jun-05", IsSelected: false},
+				{Month: "May", Year: "2005", Option: "May-05", IsSelected: false},
+			},
+			Months:     []string{"Select", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
+			Years:      []string{"Select", "2005", "2006", "2007"},
+			FormAction: timeModel.Link{Label: "", URL: "/filters/12349876/dimensions/time/update"},
+			Type:       "month",
+			GroupedSelection: timeModel.GroupedSelection{
+				Months: []timeModel.Month{
+					{
+						Name:       "January",
+						IsSelected: false,
 					},
-					YearStart: "",
-					YearEnd:   "",
+					{
+						Name:       "February",
+						IsSelected: false,
+					},
+					{
+						Name:       "March",
+						IsSelected: false,
+					},
+					{
+						Name:       "April",
+						IsSelected: false,
+					},
+					{
+						Name:       "May",
+						IsSelected: false,
+					},
+					{
+						Name:       "June",
+						IsSelected: false,
+					},
+					{
+						Name:       "July",
+						IsSelected: false,
+					},
+					{
+						Name:       "August",
+						IsSelected: false,
+					},
+					{
+						Name:       "September",
+						IsSelected: false,
+					},
+					{
+						Name:       "October",
+						IsSelected: false,
+					},
+					{
+						Name:       "November",
+						IsSelected: false,
+					},
+					{
+						Name:       "December",
+						IsSelected: false,
+					},
 				},
 			},
-			FilterID: "",
-		}
-		req := httptest.NewRequest("", "/", nil)
-		filterModel := getTestFilter()
-		datasetDetails := getTestDataset()
-		// Never actually used in the mapper but func requires it so leaving blank until needed in a test
-		datasetVersion := dataset.Version{}
-		options := getTestDatasetTimeOptions()
-		dimensionOptions := []filter.DimensionOption{{}}
-		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
-		datasetID := "cpih01"
-		apiRouterVersion := "v1"
-		lang := dprequest.DefaultLang
-		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, dimensionOptions, versionDimensions, datasetID, apiRouterVersion, lang)
-		So(err, ShouldBeNil)
-		So(timeModelPage.Data.GroupedSelection, ShouldResemble, desiredPageModel.Data.GroupedSelection)
-		So(timeModelPage.Data.Months, ShouldResemble, desiredPageModel.Data.Months)
-		So(timeModelPage.Data.Years, ShouldResemble, desiredPageModel.Data.Years)
+		},
+	}
+	p.FilterID = filterID
+	p.DatasetId = datasetID
+	p.DatasetTitle = "Small Area Population Estimates"
+	p.IsInFilterBreadcrumb = true
+	p.Metadata = model.Metadata{Title: "Time"}
+	p.SearchDisabled = true
+	p.BetaBannerEnabled = true
+	p.Language = lang
+	p.CookiesPolicy = model.CookiesPolicy{Essential: true}
+	p.Breadcrumb = []model.TaxonomyNode{
+		{
+			Title: "Small Area Population Estimates",
+			URI:   "/datasets//editions",
+		},
+		{
+			Title: "5678",
+			URI:   "/v1/datasets/1234/editions/5678/versions/1",
+		},
+		{
+			Title: "Filter options",
+			URI:   "/filters/12349876/dimensions",
+		},
+		{
+			Title: "Time",
+		},
+	}
+	return p
+}
+
+func TestIsTimeRange(t *testing.T) {
+	t0, _ := time.Parse("Jan-06", "Jan-21")
+	t1, _ := time.Parse("Jan-06", "Feb-21")
+	t2, _ := time.Parse("Jan-06", "Mar-21")
+	t3, _ := time.Parse("Jan-06", "Apr-21")
+	t4, _ := time.Parse("Jan-06", "May-21")
+	t5, _ := time.Parse("Jan-06", "Jun-21")
+	t6, _ := time.Parse("Jan-06", "Jul-21")
+	t7, _ := time.Parse("Jan-06", "Aug-21")
+	t8, _ := time.Parse("Jan-06", "Sep-21")
+	t9, _ := time.Parse("Jan-06", "Oct-21")
+	sortedTimes := []time.Time{t0, t1, t2, t3, t4, t5, t6, t7, t8, t9}
+
+	Convey("Given an empty array of selected values", t, func() {
+		selVals := []filter.DimensionOption{}
+		Convey("Then isTimeRange returns false", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeFalse)
+		})
 	})
 
+	Convey("Given a single selected value", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "Apr-21"},
+		}
+		Convey("Then isTimeRange returns false", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeFalse)
+		})
+	})
+
+	Convey("Given two chronologically consecutive selected values", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "May-21"},
+			{Option: "Apr-21"},
+		}
+		Convey("Then isTimeRange returns true", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeTrue)
+		})
+	})
+
+	Convey("Given two chronologically discontinuous selected values", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "Sep-21"},
+			{Option: "Apr-21"},
+		}
+		Convey("Then isTimeRange returns false", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeFalse)
+		})
+	})
+
+	Convey("Given six chronologically consecutive selected values", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "May-21"},
+			{Option: "Apr-21"},
+			{Option: "Jun-21"},
+			{Option: "Feb-21"},
+			{Option: "Jul-21"},
+			{Option: "Mar-21"},
+		}
+		Convey("Then isTimeRange returns true", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeTrue)
+		})
+	})
+
+	Convey("Given 2 groups of 3 chronologically consecutive selected values", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "May-21"},
+			{Option: "Jan-21"},
+			{Option: "Jun-21"},
+			{Option: "Feb-21"},
+			{Option: "Jul-21"},
+			{Option: "Mar-21"},
+		}
+		Convey("Then isTimeRange returns false", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeFalse)
+		})
+	})
+
+	Convey("Given 2 selected values with the wrong format", t, func() {
+		selVals := []filter.DimensionOption{
+			{Option: "wrong1"},
+			{Option: "wrong2"},
+		}
+		Convey("Then isTimeRange returns false", func() {
+			So(isTimeRange(sortedTimes, selVals), ShouldBeFalse)
+		})
+	})
+}
+
+func TestCreateTimePage(t *testing.T) {
+	req := httptest.NewRequest("", "/", nil)
+	datasetID := "cpih01"
+	apiRouterVersion := "v1"
+	lang := dprequest.DefaultLang
+
+	Convey("Given a valid request and all empty values, then CreateTimePage generates the expected timeModel page", t, func() {
+		expected := timeModel.Page{}
+		expected.BetaBannerEnabled = true
+		expected.CookiesPolicy = model.CookiesPolicy{Essential: true}
+
+		timeModelPage, err := CreateTimePage(req, filter.Model{}, dataset.DatasetDetails{}, dataset.Version{}, dataset.Options{}, []filter.DimensionOption{}, dataset.VersionDimensions{}, "", "", "")
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given a valid request with no selected options, then CreateTimePage generates the expected timeModel page", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		expected := getExpectedTimePage(datasetID, filterModel.FilterID, lang)
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given a valid request with a selected option, then CreateTimePage generates the expected single timeModel page", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{
+			{Option: "Apr-05"},
+		}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		expected := getExpectedTimePage(datasetID, filterModel.FilterID, lang)
+		expected.Data.Values[1] = timeModel.Value{Month: "April", Year: "2005", Option: "Apr-05", IsSelected: true}
+		expected.Data.CheckedRadio = "single"
+		expected.Data.SelectedStartMonth = "April"
+		expected.Data.SelectedStartYear = "2005"
+		expected.Data.GroupedSelection.Months[3] = timeModel.Month{
+			Name:       "April",
+			IsSelected: true,
+		}
+		expected.Data.GroupedSelection.YearStart = "2005"
+		expected.Data.GroupedSelection.YearEnd = "2005"
+
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given a valid request with the latest time option selected, even if it's not the last item in the options list, then CreateTimePage generates the expected latest timeModel page", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{
+			{Option: "Apr-07"},
+		}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		expected := getExpectedTimePage(datasetID, filterModel.FilterID, lang)
+		expected.Data.Values[0] = timeModel.Value{Month: "April", Year: "2007", Option: "Apr-07", IsSelected: true}
+		expected.Data.CheckedRadio = "latest"
+		expected.Data.GroupedSelection.Months[3] = timeModel.Month{
+			Name:       "April",
+			IsSelected: true,
+		}
+		expected.Data.GroupedSelection.YearStart = "2007"
+		expected.Data.GroupedSelection.YearEnd = "2007"
+
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given a valid request with two non-chronologically-consecutive selected options, then CreateTimePage generates the expected list timeModel page", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{
+			{Option: "Apr-05"},
+			{Option: "Apr-07"},
+		}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		expected := getExpectedTimePage(datasetID, filterModel.FilterID, lang)
+		expected.Data.Values[0] = timeModel.Value{Month: "April", Year: "2007", Option: "Apr-07", IsSelected: true}
+		expected.Data.Values[1] = timeModel.Value{Month: "April", Year: "2005", Option: "Apr-05", IsSelected: true}
+		expected.Data.CheckedRadio = "list"
+		expected.Data.GroupedSelection.Months[3] = timeModel.Month{
+			Name:       "April",
+			IsSelected: true,
+		}
+		expected.Data.GroupedSelection.YearStart = "2005"
+		expected.Data.GroupedSelection.YearEnd = "2007"
+
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given a valid request with three chronologically consecutive selected options, then CreateTimePage generates the expected range timeModel page", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{
+			{Option: "Jun-05"},
+			{Option: "Apr-05"},
+			{Option: "May-05"},
+		}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		expected := getExpectedTimePage(datasetID, filterModel.FilterID, lang)
+		expected.Data.Values[1] = timeModel.Value{Month: "April", Year: "2005", Option: "Apr-05", IsSelected: true}
+		expected.Data.Values[4] = timeModel.Value{Month: "May", Year: "2005", Option: "May-05", IsSelected: true}
+		expected.Data.Values[3] = timeModel.Value{Month: "June", Year: "2005", Option: "Jun-05", IsSelected: true}
+		expected.Data.CheckedRadio = "range"
+		expected.Data.GroupedSelection.Months[3] = timeModel.Month{
+			Name:       "April",
+			IsSelected: true,
+		}
+		expected.Data.GroupedSelection.Months[4] = timeModel.Month{
+			Name:       "May",
+			IsSelected: true,
+		}
+		expected.Data.GroupedSelection.Months[5] = timeModel.Month{
+			Name:       "June",
+			IsSelected: true,
+		}
+		expected.Data.SelectedStartMonth = "April"
+		expected.Data.SelectedStartYear = "2005"
+		expected.Data.SelectedEndMonth = "June"
+		expected.Data.SelectedEndYear = "2005"
+		expected.Data.GroupedSelection.YearStart = "2005"
+		expected.Data.GroupedSelection.YearEnd = "2005"
+
+		timeModelPage, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldBeNil)
+		So(timeModelPage, ShouldResemble, expected)
+	})
+
+	Convey("Given an invalid URL link, then CreateTimePage returns the expected error", t, func() {
+		filterModel := getTestFilter()
+		filterModel.Links.Version.HRef = "invalid%url"
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		selectedOptions := []filter.DimensionOption{}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		_, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "parse \"invalid%url\": invalid URL escape \"%ur\"")
+	})
+
+	Convey("Given that one of the dimension options has the wrong format, then CreateTimePage returns the expected error", t, func() {
+		filterModel := getTestFilter()
+		datasetDetails := getTestDataset()
+		datasetVersion := dataset.Version{}
+		options := getTestDatasetTimeOptions()
+		options.Items[3].Label = "wrongFormat"
+		selectedOptions := []filter.DimensionOption{}
+		versionDimensions := dataset.VersionDimensions{Items: getTestDatasetDimensions()}
+
+		_, err := CreateTimePage(req, filterModel, datasetDetails, datasetVersion, options, selectedOptions, versionDimensions, datasetID, apiRouterVersion, lang)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "parsing time \"wrongFormat\" as \"Jan-06\": cannot parse \"wrongFormat\" as \"Jan\"")
+	})
 }
 
 // getTestDatasetAgeOptions returns an age dataset.Options for testing, with items sorted in a an order that is not from youngest to oldest

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -152,7 +152,7 @@ func TestUnitMapper(t *testing.T) {
 			So(p.Data.FiltersAmount, ShouldEqual, 2)
 		})
 
-		Convey("correctly orders the time values into ascending numeric order", func() {
+		Convey("keeps the same order for the time values as provided by dataset API", func() {
 			p := CreateListSelectorPage(req, "time", []filter.DimensionOption{}, dataset.Options{
 				Items: []dataset.Option{
 					{
@@ -172,13 +172,13 @@ func TestUnitMapper(t *testing.T) {
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 
-			So(p.Data.RangeData.Values[0].Label, ShouldEqual, "2017")
-			So(p.Data.RangeData.Values[1].Label, ShouldEqual, "2013")
-			So(p.Data.RangeData.Values[2].Label, ShouldEqual, "2010")
-			So(p.Data.RangeData.Values[3].Label, ShouldEqual, "2009")
+			So(p.Data.RangeData.Values[0].Label, ShouldEqual, "2013")
+			So(p.Data.RangeData.Values[1].Label, ShouldEqual, "2010")
+			So(p.Data.RangeData.Values[2].Label, ShouldEqual, "2009")
+			So(p.Data.RangeData.Values[3].Label, ShouldEqual, "2017")
 		})
 
-		Convey("correctly orders non time/age values alphabetically", func() {
+		Convey("keeps the same order for the non time/age values as provided by dataset API", func() {
 			p := CreateListSelectorPage(req, "geography", []filter.DimensionOption{}, dataset.Options{
 				Items: []dataset.Option{
 					{
@@ -198,10 +198,10 @@ func TestUnitMapper(t *testing.T) {
 
 			So(len(p.Data.RangeData.Values), ShouldEqual, 4)
 
-			So(p.Data.RangeData.Values[0].Label, ShouldEqual, "England")
-			So(p.Data.RangeData.Values[1].Label, ShouldEqual, "Ireland")
-			So(p.Data.RangeData.Values[2].Label, ShouldEqual, "Scotland")
-			So(p.Data.RangeData.Values[3].Label, ShouldEqual, "Wales")
+			So(p.Data.RangeData.Values[0].Label, ShouldEqual, "Wales")
+			So(p.Data.RangeData.Values[1].Label, ShouldEqual, "Scotland")
+			So(p.Data.RangeData.Values[2].Label, ShouldEqual, "England")
+			So(p.Data.RangeData.Values[3].Label, ShouldEqual, "Ireland")
 		})
 
 	})


### PR DESCRIPTION
### What

- Removed remaining ordering logic for non-hierarchy dimension options
- Use order value returned by hierarchy API to sort the flattened geography items.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info): this has been tested locally with the following:
  - code-list: `administrative-geography`
  - imported dataset: `older-people-sex-ratios`

### Who can review

Anyone