### PR TITLE
Bugfix: check if child is nil

### DIFF
--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -336,7 +336,7 @@ func (n flatNodes) addWithChildren(val hierarchy.Child, i int) {
 // hasOrder returns true if and only if all child items in the list have a non-nil order values
 func (n flatNodes) hasOrder() bool {
 	for _, child := range n.list {
-		if child.Order == nil {
+		if child == nil || child.Order == nil {
 			return false
 		}
 	}


### PR DESCRIPTION
### What

Bugfix:
After the changes to support the order from the frontend, a bug was introduced. For example:
https://www.develop.onsdigital.co.uk/filters/1c9c6beb-652c-48b8-90d8-df9c058a8660/dimensions/geography returns a 503 due to a panic caused by a nil ponter.

This PR fixes this issue.

### How to review

- Make sure code change make sense
- Make sure unit tests pass

### Who can review

Anyone