### PR TITLE
Added comprehensive checks for flatNodes to prevent any possible pani…

### DIFF
--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -334,6 +334,7 @@ func (n *flatNodes) hasOrder() bool {
 	if n.list == nil {
 		return false
 	}
+
 	for _, child := range n.list {
 		if child.Order == nil {
 			return false
@@ -345,18 +346,32 @@ func (n *flatNodes) hasOrder() bool {
 // getOrder obtains the order value, with paramater checking, and assuming that it's not nil
 // returns the order value, or -1 if any parameter check failed or the order was nil
 func (n *flatNodes) getOrder(i int) int {
-	if n.list == nil || i >= len(n.list) || n.list[i].Order == nil {
+	if n.list == nil {
 		return -1
 	}
+	if i >= len(n.list) {
+		return -1
+	}
+	if n.list[i].Order == nil {
+		return -1
+	}
+
 	return *n.list[i].Order
 }
 
 // getDefaultOrder obtains the default order value according to the defaultOrder slice, with parameter checking
 // returns the default order value corresponding to the child item in the provided index, or -1 if not defined
 func (n *flatNodes) getDefaultOrder(i int) int {
-	if n.list == nil || i >= len(n.list) || n.list[i].Links.Code.ID == "" {
+	if n.list == nil {
 		return -1
 	}
+	if i >= len(n.list) {
+		return -1
+	}
+	if n.list[i].Links.Code.ID == "" {
+		return -1
+	}
+
 	order, ok := n.defaultOrder[n.list[i].Links.Code.ID]
 	if !ok {
 		return -1
@@ -366,9 +381,13 @@ func (n *flatNodes) getDefaultOrder(i int) int {
 
 // sort child items by order property, or by default values as fallback (if order is not defined in all items)
 func (n *flatNodes) sort() {
-	if n.list == nil || len(n.list) == 0 {
+	if n.list == nil {
 		return
 	}
+	if len(n.list) == 0 {
+		return
+	}
+
 	if n.hasOrder() {
 		sort.Slice(n.list, func(i, j int) bool {
 			return n.getOrder(i) < n.getOrder(j)

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -112,6 +112,10 @@ func (f *Filter) buildHierarchyModel(ctx context.Context, fil filter.Model, name
 		h, err = f.HierarchyClient.GetRoot(ctx, fil.InstanceID, name)
 	}
 
+	if err != nil {
+		return h, err
+	}
+
 	// We include the value on the root as a selectable item, so append
 	// the value on the root to the child to see if it has been removed by
 	// the user

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -350,6 +350,7 @@ func (n *flatNodes) hasOrder() bool {
 // getOrder obtains the order value, with paramater checking, and assuming that it's not nil
 // returns the order value, or -1 if any parameter check failed or the order was nil
 func (n *flatNodes) getOrder(i int) int {
+	// split checks over separate if's so that code coverage can be related to unit test code
 	if n.list == nil {
 		return -1
 	}
@@ -366,6 +367,7 @@ func (n *flatNodes) getOrder(i int) int {
 // getDefaultOrder obtains the default order value according to the defaultOrder slice, with parameter checking
 // returns the default order value corresponding to the child item in the provided index, or -1 if not defined
 func (n *flatNodes) getDefaultOrder(i int) int {
+	// split checks over separate if's so that code coverage can be related to unit test code
 	if n.list == nil {
 		return -1
 	}
@@ -385,6 +387,7 @@ func (n *flatNodes) getDefaultOrder(i int) int {
 
 // sort child items by order property, or by default values as fallback (if order is not defined in all items)
 func (n *flatNodes) sort() {
+	// split checks over separate if's so that code coverage can be related to unit test code
 	if n.list == nil {
 		return
 	}

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -307,7 +307,7 @@ type flatNodes struct {
 }
 
 func (n *flatNodes) addWithoutChildren(val hierarchy.Child) {
-	if n == nil || !val.HasData {
+	if !val.HasData {
 		return
 	}
 
@@ -320,9 +320,6 @@ func (n *flatNodes) addWithoutChildren(val hierarchy.Child) {
 }
 
 func (n *flatNodes) addWithChildren(val hierarchy.Child) {
-	if n == nil {
-		return
-	}
 	n.list = append(n.list, &hierarchy.Child{
 		Label:            val.Label,
 		Links:            val.Links,
@@ -334,7 +331,7 @@ func (n *flatNodes) addWithChildren(val hierarchy.Child) {
 
 // hasOrder returns true if and only if all child items in the list have a non-nil order values
 func (n *flatNodes) hasOrder() bool {
-	if n == nil || n.list == nil {
+	if n.list == nil {
 		return false
 	}
 	for _, child := range n.list {
@@ -348,7 +345,7 @@ func (n *flatNodes) hasOrder() bool {
 // getOrder obtains the order value, with paramater checking, and assuming that it's not nil
 // returns the order value, or -1 if any parameter check failed or the order was nil
 func (n *flatNodes) getOrder(i int) int {
-	if n == nil || n.list == nil || i >= len(n.list) || n.list[i] == nil || n.list[i].Order == nil {
+	if n.list == nil || i >= len(n.list) || n.list[i] == nil || n.list[i].Order == nil {
 		return -1
 	}
 	return *n.list[i].Order
@@ -357,7 +354,7 @@ func (n *flatNodes) getOrder(i int) int {
 // getDefaultOrder obtains the default order value according to the defaultOrder slice, with parameter checking
 // returns the default order value corresponding to the child item in the provided index, or -1 if not defined
 func (n *flatNodes) getDefaultOrder(i int) int {
-	if n == nil || n.list == nil || i >= len(n.list) || n.list[i] == nil || n.list[i].Links.Code.ID == "" {
+	if n.list == nil || i >= len(n.list) || n.list[i] == nil || n.list[i].Links.Code.ID == "" {
 		return -1
 	}
 	order, ok := n.defaultOrder[n.list[i].Links.Code.ID]
@@ -369,7 +366,7 @@ func (n *flatNodes) getDefaultOrder(i int) int {
 
 // sort child items by order property, or by default values as fallback (if order is not defined in all items)
 func (n *flatNodes) sort() {
-	if n == nil || n.list == nil || len(n.list) == 0 {
+	if n.list == nil || len(n.list) == 0 {
 		return
 	}
 	if n.hasOrder() {

--- a/handlers/hierarchy.go
+++ b/handlers/hierarchy.go
@@ -355,7 +355,7 @@ func (n *flatNodes) getOrder(i int) int {
 }
 
 // getDefaultOrder obtains the default order value according to the defaultOrder slice, with parameter checking
-// returns the default order, and ok=true only if a non-nil order was found for the child in the ist corresponding to the provided index
+// returns the default order value corresponding to the child item in the provided index, or -1 if not defined
 func (n *flatNodes) getDefaultOrder(i int) int {
 	if n == nil || n.list == nil || i >= len(n.list) || n.list[i] == nil || n.list[i].Links.Code.ID == "" {
 		return -1

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -650,11 +650,11 @@ func TestFlatNodes_AddWithChildren(t *testing.T) {
 	}
 
 	Convey("given an empty flatNodes", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 
 		Convey("Then addWithChildren will add the child value to the list", func() {
 			n.addWithChildren(testChild)
-			So(*n, ShouldResemble, flatNodes{
+			So(n, ShouldResemble, flatNodes{
 				list: []hierarchy.Child{testChild},
 			})
 		})
@@ -692,18 +692,18 @@ func TestFlatNodes_AddWithoutChildren(t *testing.T) {
 	})
 
 	Convey("given an empty flatNodes", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 
 		Convey("Then addWithoutChildren with a child that has data will add the child value to the list", func() {
 			n.addWithoutChildren(testChildWithData)
-			So(*n, ShouldResemble, flatNodes{
+			So(n, ShouldResemble, flatNodes{
 				list: []hierarchy.Child{testChildWithData},
 			})
 		})
 
 		Convey("Then addWithoutChildren with a child that does not have data will not add the child value to the list", func() {
 			n.addWithoutChildren(testChildWithoutData)
-			So(*n, ShouldResemble, flatNodes{})
+			So(n, ShouldResemble, flatNodes{})
 		})
 	})
 }
@@ -714,12 +714,12 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 	order2 := 2
 
 	Convey("given an empty flatNodes, then hasOrder returns false", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 		So(n.hasOrder(), ShouldBeFalse)
 	})
 
 	Convey("given a flatNodes with all items in the list having order, then hasOrder returns true", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: &order2},
@@ -729,7 +729,7 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with a mixture of items with order and items without order in the list, then hasOrder returns false", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: nil},
@@ -739,7 +739,7 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with all items in the list not having order, then hasOrder returns false", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: nil},
 				{Label: "child2", Order: nil},
@@ -755,12 +755,12 @@ func TestFlatNodes_GetOrder(t *testing.T) {
 	order2 := 2
 
 	Convey("given an empty flatNodes, then getOrder returns -1", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 		So(n.getOrder(0), ShouldEqual, -1)
 	})
 
 	Convey("given a flatNodes with items with order and without order", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: &order2},
@@ -782,12 +782,12 @@ func TestFlatNodes_GetDefaultOrder(t *testing.T) {
 	order1 := 1
 
 	Convey("given an empty flatNodes, then getDefaultOrder returns -1", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 		So(n.getDefaultOrder(0), ShouldEqual, -1)
 	})
 
 	Convey("given a flatNodes with a list of unordered items but without a default order list", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 			},
@@ -800,7 +800,7 @@ func TestFlatNodes_GetDefaultOrder(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with a list of unordered items and a default order list", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
@@ -838,7 +838,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with a list of children with order", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order3},
 				{Label: "child2", Order: &order4},
@@ -849,7 +849,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 
 		Convey("Then sort sorts the list of children according to their order values, incrementally", func() {
 			n.sort()
-			So(*n, ShouldResemble, flatNodes{
+			So(n, ShouldResemble, flatNodes{
 				list: []hierarchy.Child{
 					{Label: "child3", Order: &order1},
 					{Label: "child4", Order: &order2},
@@ -861,7 +861,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with a list of children where at least one of them does not have order, and a list of default orders that contains default order for all the items in list", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
@@ -888,7 +888,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 	})
 
 	Convey("given a flatNodes with a list of children where at least one of them does not have order, and a list of default orders that does not contain some of the items in list", t, func() {
-		var n *flatNodes = &flatNodes{
+		var n flatNodes = flatNodes{
 			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -655,7 +655,7 @@ func TestFlatNodes_AddWithChildren(t *testing.T) {
 		Convey("Then addWithChildren will add the child value to the list", func() {
 			n.addWithChildren(testChild)
 			So(*n, ShouldResemble, flatNodes{
-				list: []*hierarchy.Child{&testChild},
+				list: []hierarchy.Child{testChild},
 			})
 		})
 	})
@@ -697,7 +697,7 @@ func TestFlatNodes_AddWithoutChildren(t *testing.T) {
 		Convey("Then addWithoutChildren with a child that has data will add the child value to the list", func() {
 			n.addWithoutChildren(testChildWithData)
 			So(*n, ShouldResemble, flatNodes{
-				list: []*hierarchy.Child{&testChildWithData},
+				list: []hierarchy.Child{testChildWithData},
 			})
 		})
 
@@ -720,7 +720,7 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 
 	Convey("given a flatNodes with all items in the list having order, then hasOrder returns true", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: &order2},
 			},
@@ -728,26 +728,9 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 		So(n.hasOrder(), ShouldBeTrue)
 	})
 
-	Convey("given a flatNodes with nil items in the list, then hasOrder returns false", t, func() {
-		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{nil, nil},
-		}
-		So(n.hasOrder(), ShouldBeFalse)
-	})
-
-	Convey("given a flatNodes with a mixture of items with order and nil values in the list, then hasOrder returns false", t, func() {
-		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
-				{Label: "child1", Order: &order1},
-				nil,
-			},
-		}
-		So(n.hasOrder(), ShouldBeFalse)
-	})
-
 	Convey("given a flatNodes with a mixture of items with order and items without order in the list, then hasOrder returns false", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: nil},
 			},
@@ -757,7 +740,7 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 
 	Convey("given a flatNodes with all items in the list not having order, then hasOrder returns false", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: nil},
 				{Label: "child2", Order: nil},
 			},
@@ -778,11 +761,10 @@ func TestFlatNodes_GetOrder(t *testing.T) {
 
 	Convey("given a flatNodes with items with order and without order", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1},
 				{Label: "child2", Order: &order2},
 				{Label: "child3", Order: nil},
-				nil,
 			},
 		}
 
@@ -806,7 +788,7 @@ func TestFlatNodes_GetDefaultOrder(t *testing.T) {
 
 	Convey("given a flatNodes with a list of unordered items but without a default order list", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 			},
 		}
@@ -819,13 +801,12 @@ func TestFlatNodes_GetDefaultOrder(t *testing.T) {
 
 	Convey("given a flatNodes with a list of unordered items and a default order list", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
 				{Label: "child3", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{}}},
 				{Label: "child4", Order: nil, Links: hierarchy.Links{}},
 				{Label: "child5", Order: nil},
-				nil,
 			},
 			defaultOrder: map[string]int{
 				"code1": order1,
@@ -851,14 +832,14 @@ func TestFlatNodes_Sort(t *testing.T) {
 	order4 := 4
 
 	Convey("given an empty flatNodes, then sort does not panic", t, func() {
-		var n *flatNodes = &flatNodes{}
+		var n flatNodes = flatNodes{}
 		n.sort()
-		So(*n, ShouldResemble, flatNodes{})
+		So(n, ShouldResemble, flatNodes{})
 	})
 
 	Convey("given a flatNodes with a list of children with order", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order3},
 				{Label: "child2", Order: &order4},
 				{Label: "child3", Order: &order1},
@@ -869,7 +850,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 		Convey("Then sort sorts the list of children according to their order values, incrementally", func() {
 			n.sort()
 			So(*n, ShouldResemble, flatNodes{
-				list: []*hierarchy.Child{
+				list: []hierarchy.Child{
 					{Label: "child3", Order: &order1},
 					{Label: "child4", Order: &order2},
 					{Label: "child1", Order: &order3},
@@ -881,7 +862,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 
 	Convey("given a flatNodes with a list of children where at least one of them does not have order, and a list of default orders that contains default order for all the items in list", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
 				{Label: "child3", Order: &order3, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code3"}}},
@@ -897,7 +878,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 
 		Convey("Then sort sorts the list of children according to the default order values, incrementally", func() {
 			n.sort()
-			So(n.list, ShouldResemble, []*hierarchy.Child{
+			So(n.list, ShouldResemble, []hierarchy.Child{
 				{Label: "child3", Order: &order3, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code3"}}},
 				{Label: "child4", Order: &order4, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code4"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
@@ -908,7 +889,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 
 	Convey("given a flatNodes with a list of children where at least one of them does not have order, and a list of default orders that does not contain some of the items in list", t, func() {
 		var n *flatNodes = &flatNodes{
-			list: []*hierarchy.Child{
+			list: []hierarchy.Child{
 				{Label: "child1", Order: &order1, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code1"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},
 				{Label: "child3", Order: &order3, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code3"}}},
@@ -923,7 +904,7 @@ func TestFlatNodes_Sort(t *testing.T) {
 
 		Convey("Then sort sorts the list of children according to the default order values that exist, incrementally, after the ones that do not have a default order, which appear first in the list", func() {
 			n.sort()
-			So(n.list, ShouldResemble, []*hierarchy.Child{
+			So(n.list, ShouldResemble, []hierarchy.Child{
 				{Label: "child4", Order: &order4, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code4"}}},
 				{Label: "child3", Order: &order3, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code3"}}},
 				{Label: "child2", Order: nil, Links: hierarchy.Links{Code: hierarchy.Link{ID: "code2"}}},

--- a/handlers/hierarchy_test.go
+++ b/handlers/hierarchy_test.go
@@ -649,12 +649,6 @@ func TestFlatNodes_AddWithChildren(t *testing.T) {
 		NumberofChildren: 2,
 	}
 
-	Convey("given a nil flatNodes variable, then addWithChildren does not panic", t, func() {
-		var n *flatNodes = nil
-		n.addWithChildren(hierarchy.Child{})
-		So(n, ShouldBeNil)
-	})
-
 	Convey("given an empty flatNodes", t, func() {
 		var n *flatNodes = &flatNodes{}
 
@@ -719,11 +713,6 @@ func TestFlatNodes_HasOrder(t *testing.T) {
 	order1 := 1
 	order2 := 2
 
-	Convey("given a nil flatNodes variable, then hasOrder does not panic and returns false", t, func() {
-		var n *flatNodes = nil
-		So(n.hasOrder(), ShouldBeFalse)
-	})
-
 	Convey("given an empty flatNodes, then hasOrder returns false", t, func() {
 		var n *flatNodes = &flatNodes{}
 		So(n.hasOrder(), ShouldBeFalse)
@@ -782,12 +771,6 @@ func TestFlatNodes_GetOrder(t *testing.T) {
 	order1 := 1
 	order2 := 2
 
-	Convey("given a nil flatNodes variable, then getOrder does not panic and returns -1", t, func() {
-		var n *flatNodes = nil
-		So(n.getOrder(0), ShouldEqual, -1)
-		So(n, ShouldBeNil)
-	})
-
 	Convey("given an empty flatNodes, then getOrder returns -1", t, func() {
 		var n *flatNodes = &flatNodes{}
 		So(n.getOrder(0), ShouldEqual, -1)
@@ -815,12 +798,6 @@ func TestFlatNodes_GetOrder(t *testing.T) {
 func TestFlatNodes_GetDefaultOrder(t *testing.T) {
 
 	order1 := 1
-
-	Convey("given a nil flatNodes variable, then getDefaultOrder does not panic and returns -1", t, func() {
-		var n *flatNodes = nil
-		So(n.getDefaultOrder(0), ShouldEqual, -1)
-		So(n, ShouldBeNil)
-	})
 
 	Convey("given an empty flatNodes, then getDefaultOrder returns -1", t, func() {
 		var n *flatNodes = &flatNodes{}
@@ -872,12 +849,6 @@ func TestFlatNodes_Sort(t *testing.T) {
 	order2 := 2
 	order3 := 3
 	order4 := 4
-
-	Convey("given a nil flatNodes variable, then sort does not panic", t, func() {
-		var n *flatNodes = nil
-		n.sort()
-		So(n, ShouldBeNil)
-	})
 
 	Convey("given an empty flatNodes, then sort does not panic", t, func() {
 		var n *flatNodes = &flatNodes{}


### PR DESCRIPTION
### What

Added comprehensive checks for flatNodes to prevent any possible panic or nil pointer:
- create flatNode without initial length, and append items as they appear (this prevent having a list with nil values for nodes that are not defined)
- added more flatNode functions, with all proper parameter checks (nil, empty values, out of range, etc)
- added comprehensive unit tests for the new changes
- added some extra flattenGeographyTopLevel test cases for getRoot or getChild returning empty responses.

This should fix the bug that the data team identified, described here: 
https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/282
(that PR only fixed the issue partially, hence the bug was still reproducible)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass, and that the new tests make sense

### Who can review

Anyone