### PR TITLE
Fix to error handling on filter journey when js is disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.4
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0
-	github.com/ONSdigital/dp-frontend-models v1.9.1
+	github.com/ONSdigital/dp-frontend-models v1.12.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ONSdigital/dp-frontend-dataset-controller v1.17.0/go.mod h1:y54tYUkR/
 github.com/ONSdigital/dp-frontend-models v1.6.2/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.9.1 h1:FtoZAxoxjvCQpj8U23usBSv9MhDCsqj+TdpVndbEeXk=
 github.com/ONSdigital/dp-frontend-models v1.9.1/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.12.0 h1:sCquTZu8G5TQZMh4OexJKYiGhSKgszufZInYw+87oPs=
+github.com/ONSdigital/dp-frontend-models v1.12.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=

--- a/handlers/filter-overview.go
+++ b/handlers/filter-overview.go
@@ -27,6 +27,8 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 		filterID := vars["filterID"]
 		ctx := req.Context()
 
+		hasUnsetDimensions := req.URL.Query().Get("hasUnsetDimensions")
+
 		dims, eTag0, err := f.FilterClient.GetDimensions(req.Context(), userAccessToken, "", collectionID, filterID, nil)
 		if err != nil {
 			log.Event(ctx, "failed to get dimensions", log.ERROR, log.Error(err), log.Data{"filter_id": filterID})
@@ -140,6 +142,10 @@ func (f *Filter) FilterOverview() http.HandlerFunc {
 
 		p.Data.LatestVersion.DatasetLandingPageURL = latestVersionInEditionPath
 		p.Data.LatestVersion.FilterJourneyWithLatestJourney = fmt.Sprintf("/filters/%s/use-latest-version", filterID)
+
+		if hasUnsetDimensions == "true" {
+			p.Data.HasUnsetDimensions = true
+		}
 
 		b, err := json.Marshal(p)
 		if err != nil {

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/ONSdigital/dp-api-clients-go/filter"
 	"github.com/ONSdigital/log.go/log"
 )
 
@@ -15,7 +16,7 @@ func ExtractDatasetInfoFromPath(ctx context.Context, path string) (datasetID, ed
 	pathReg := regexp.MustCompile(`\/datasets\/(.+)\/editions\/(.+)\/versions\/(.+)`)
 	subs := pathReg.FindStringSubmatch(path)
 	if len(subs) < 4 {
-		err = fmt.Errorf("unabled to extract datasetID, edition and version from path: %s", path)
+		err = fmt.Errorf("unable to extract datasetID, edition and version from path: %s", path)
 		return
 	}
 	return subs[1], subs[2], subs[3], nil
@@ -39,4 +40,19 @@ func StringInSlice(str string, slice []string) (int, bool) {
 		}
 	}
 	return -1, false
+}
+
+// Check each dimension has an option selected
+func CheckAllDimensionsHaveAnOption(dims []filter.ModelDimension) (check bool, err error) {
+	if len(dims) == 0 {
+		err = fmt.Errorf("no dimensions provided: %s", dims)
+		return
+	}
+	check = true
+	for _, dim := range dims {
+		if len(dim.Options) == 0 {
+			check = false
+		}
+	}
+	return
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/filter"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -21,7 +22,7 @@ func TestUnitHelpers(t *testing.T) {
 
 		Convey("returns an error if it is unable to extract the information", func() {
 			datasetID, edition, version, err := ExtractDatasetInfoFromPath(ctx, "invalid")
-			So(err.Error(), ShouldEqual, "unabled to extract datasetID, edition and version from path: invalid")
+			So(err.Error(), ShouldEqual, "unable to extract datasetID, edition and version from path: invalid")
 			So(datasetID, ShouldEqual, "")
 			So(edition, ShouldEqual, "")
 			So(version, ShouldEqual, "")
@@ -145,5 +146,206 @@ func TestStringInSlice(t *testing.T) {
 				})
 			})
 		})
+	})
+}
+
+// TestCheckAllDimensionHaveAnOption test the helper function CheckAllDimensionsHaveAnOption
+func TestCheckAllDimensionHaveAnOption(t *testing.T) {
+	Convey("No dimesions provided return error", t, func() {
+		testDimensions := []filter.ModelDimension{}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err.Error(), ShouldEqual, "no dimensions provided: []")
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("All dimensions have an option return true", t, func() {
+		testDimensions := []filter.ModelDimension{{
+			Name:    "test",
+			Options: []string{"option"},
+		}}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, true)
+	})
+
+	Convey("Dimension with no option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{{
+			Name:    "test",
+			Options: []string{},
+		}}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Two dimensions with options selected return true", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test2",
+				Options: []string{"option2"},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, true)
+	})
+
+	Convey("Two dimensions with no options selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{},
+			},
+			{
+				Name:    "test2",
+				Options: []string{},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Two dimensions with one option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test2",
+				Options: []string{},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Two dimensions with one option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{},
+			},
+			{
+				Name:    "test2",
+				Options: []string{"option1"},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Three dimensions with only last option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{},
+			},
+			{
+				Name:    "test2",
+				Options: []string{},
+			},
+			{
+				Name:    "test3",
+				Options: []string{"option1"},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Three dimensions with only first option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test2",
+				Options: []string{},
+			},
+			{
+				Name:    "test3",
+				Options: []string{},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Five dimensions with only middle option selected return false", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{},
+			},
+			{
+				Name:    "test2",
+				Options: []string{},
+			},
+			{
+				Name:    "test3",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test4",
+				Options: []string{},
+			},
+			{
+				Name:    "test5",
+				Options: []string{},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, false)
+	})
+
+	Convey("Five dimensions with option in each return true", t, func() {
+		testDimensions := []filter.ModelDimension{
+			{
+				Name:    "test",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test2",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test3",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test4",
+				Options: []string{"option1"},
+			},
+			{
+				Name:    "test5",
+				Options: []string{"option1"},
+			},
+		}
+
+		sut, err := CheckAllDimensionsHaveAnOption(testDimensions)
+		So(err, ShouldBeNil)
+		So(sut, ShouldEqual, true)
 	})
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -57,14 +57,8 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 	p.Language = lang
 	p.URI = req.URL.Path
 
-	disableButton := true
-
 	for _, d := range dimensions {
 		var fod filterOverview.Dimension
-
-		if len(d.Values) > 0 {
-			disableButton = false
-		}
 
 		if d.Name == "time" {
 			for _, dim := range datasetDims {
@@ -104,13 +98,11 @@ func CreateFilterOverview(req *http.Request, dimensions []filter.ModelDimension,
 			fod.Link.Label = "Edit"
 		} else {
 			fod.Link.Label = "Add"
+			fod.HasNoCategory = true
+			p.Data.UnsetDimensions = append(p.Data.UnsetDimensions, fod.Filter)
 		}
 
 		p.Data.Dimensions = append(p.Data.Dimensions, fod)
-	}
-
-	if p.Data.PreviewAndDownloadDisabled = disableButton; !p.Data.PreviewAndDownloadDisabled {
-		p.Data.PreviewAndDownload.URL = fmt.Sprintf("/filters/%s", filterID)
 	}
 
 	p.Data.Cancel.URL = "/"


### PR DESCRIPTION
### What

- Created check to ensure that an option has been added to the filter
- Added unit tests
- Removed unused code
- Updated dependencies

### How to review

- Make sure you have [CMD data setup](https://github.com/ONSdigital/dp/blob/main/guides/INSTALLING.md#cmd) and the overall journey working locally to see changes 
- Pull the branch with changes to the [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer/tree/fix/error-handling-on-filter-journey-no-js)
- Disable JS
- Check that an error message is shown if you click 'apply filters' with no filters added
- Sanity check
- Unit tests pass
- Check spelling

### Who can review

Anyone but me
