### PR TITLE
Tidy env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,22 @@ An HTTP service for the controlling of data relevant to the filtering of a parti
 
 ### Configuration
 
-| Environment variable          | Default                 | Description
-| ----------------------------- | ----------------------- | --------------------------------------
-| BIND_ADDR                     | :20001                  | The host and port to bind to.
-| RENDERER_URL                  | http://localhost:20010  | The URL of dp-frontend-renderer.
-| CODE_LIST_API                 | http://localhost:22400  | The URL of the code list api
-| FILTER_API_URL                | http://localhost:22100  | The URL of the filter api
-| DATASET_API_URL               | http://localhost:22000  | The URL of the dataset api
-| HIERARCHY_API_URL             | http://localhost:22600  | The URL of the hierarchy api
-| SEARCH_API_URL                | http://localhost:23100  | The URL of the search api
-| DOWNLOAD_SERVICE_URL          | http://localhost:23600  | The URL of the download service
-| ZEBEDEE_URL                   | http://localhost:8082   | The url of the zebedee service. Only required if profiler is enabled
-| DATASET_API_AUTH_TOKEN        | n/a                     | The token used to access the Dataset API
-| FILTER_API_AUTH_TOKEN         | n/a                     | The token used to access the Filter API
-| SEARCH_API_AUTH_TOKEN         | n/a                     | The token used to access the Search API
-| ENABLE_DATASET_PREVIEW        | false                   | Flag to add preview of dataset to output page
-| ENABLE_PROFILER               | false                   | Flag to enable go profiler
-| PPROF_TOKEN                   | ""                      | The profiling token to access service profiling
-| GRACEFUL_SHUTDOWN_TIMEOUT     | 5s                      | The graceful shutdown timeout in seconds
-| HEALTHCHECK_INTERVAL          | 30s                     | The time between calling healthcheck endpoints for check subsystems
-| HEALTHCHECK_CRITICAL_TIMEOUT  | 90s                     | The time taken for the health changes from warning state to critical due to subsystem check failures 
+| Environment variable         | Default                   | Description                                                                                          |
+|------------------------------|---------------------------|------------------------------------------------------------------------------------------------------|
+| API_ROUTER_URL               | http://localhost:23200/v1 | The URL of the API Router                                                                            |
+| BATCH_MAX_WORKERS            | 100                       | maximum number of concurrent go-routines requesting items concurrently from APIs with pagination     |
+| BATCH_SIZE_LIMIT             | 1000                      | maximum limit value to get items from APIs in a single call                                          |
+| BIND_ADDR                    | :20001                    | The host and port to bind to.                                                                        |
+| DOWNLOAD_SERVICE_URL         | http://localhost:23600    | The URL of the download service                                                                      |
+| ENABLE_DATASET_PREVIEW       | false                     | Flag to add preview of dataset to output page                                                        |
+| ENABLE_PROFILER              | false                     | Flag to enable go profiler                                                                           |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                        | The graceful shutdown timeout in seconds                                                             |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                       | The time taken for the health changes from warning state to critical due to subsystem check failures |
+| HEALTHCHECK_INTERVAL         | 30s                       | The time between calling healthcheck endpoints for check subsystems                                  |
+| MAX_DATASET_OPTIONS          | 200                       | maximum number of IDs that will be requested to dataset API in a single call as query parmeters      |
+| PPROF_TOKEN                  | ""                        | The profiling token to access service profiling                                                      |
+| RENDERER_URL                 | http://localhost:20010    | The URL of dp-frontend-renderer.                                                                     |
+| SEARCH_API_AUTH_TOKEN        | n/a                       | The token used to access the Search API                                                              |
 
 `HEALTHCHECK_INTERVAL` and `HEALTHCHECK_CRITICAL_TIMEOUT` can use the following formats to represent duration of time:
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,22 +8,20 @@ import (
 
 // Config represents service configuration for dp-frontend-filter-dataset-controller
 type Config struct {
-	BindAddr                   string        `envconfig:"BIND_ADDR"`
-	RendererURL                string        `envconfig:"RENDERER_URL"`
 	APIRouterURL               string        `envconfig:"API_ROUTER_URL"`
-	DatasetAPIAuthToken        string        `envconfig:"DATASET_API_AUTH_TOKEN" json:"-"`
-	FilterAPIAuthToken         string        `envconfig:"FILTER_API_AUTH_TOKEN"  json:"-"`
-	SearchAPIAuthToken         string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
+	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
+	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
+	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 	EnableDatasetPreview       bool          `envconfig:"ENABLE_DATASET_PREVIEW"`
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
-	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
-	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
-	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
-	MaxDatasetOptions          int           `envconfig:"MAX_DATASET_OPTIONS"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	MaxDatasetOptions          int           `envconfig:"MAX_DATASET_OPTIONS"`
+	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
+	RendererURL                string        `envconfig:"RENDERER_URL"`
+	SearchAPIAuthToken         string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
 }
 
 var cfg *Config
@@ -33,21 +31,18 @@ var cfg *Config
 func Get() (cfg *Config, err error) {
 
 	cfg = &Config{
-		BindAddr:                   ":20001",
-		RendererURL:                "http://localhost:20010",
 		APIRouterURL:               "http://localhost:23200/v1",
-		DatasetAPIAuthToken:        "FD0108EA-825D-411C-9B1D-41EF7727F465",
-		FilterAPIAuthToken:         "FD0108EA-825D-411C-9B1D-41EF7727F465",
-		SearchAPIAuthToken:         "SD0108EA-825D-411C-45J3-41EF7727F123",
+		BatchSizeLimit:             1000,
+		BatchMaxWorkers:            100,
+		BindAddr:                   ":20001",
 		DownloadServiceURL:         "http://localhost:23600",
 		EnableDatasetPreview:       false,
 		EnableProfiler:             false,
 		GracefulShutdownTimeout:    5 * time.Second,
-		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		BatchSizeLimit:             1000, // maximum limit value to get items from APIs in a single call
-		BatchMaxWorkers:            100,  // maximum number of concurrent go-routines requesting items concurrently from APIs with pagination
-		MaxDatasetOptions:          200,  // maximum number of IDs that will be requested to dataset API in a single call as query parmeters
+		HealthCheckInterval:        30 * time.Second,
+		MaxDatasetOptions:          200,
+		RendererURL:                "http://localhost:20010",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestConfig(t *testing.T) {
+	Convey("Given an environment with no environment variables set", t, func() {
+		os.Clearenv()
+		cfg, err := Get()
+
+		Convey("When the config values are retrieved", func() {
+
+			Convey("Then there should be no error returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the values should be set to the expected defaults", func() {
+				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
+				So(cfg.BatchSizeLimit, ShouldEqual, 1000)
+				So(cfg.BatchMaxWorkers, ShouldEqual, 100)
+				So(cfg.BindAddr, ShouldEqual, ":20001")
+				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
+				So(cfg.EnableDatasetPreview, ShouldBeFalse)
+				So(cfg.EnableProfiler, ShouldBeFalse)
+				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
+				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
+				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
+				So(cfg.MaxDatasetOptions, ShouldEqual, 200)
+				So(cfg.RendererURL, ShouldEqual, "http://localhost:20010")
+			})
+
+			Convey("Then a second call to config should return the same config", func() {
+				newCfg, newErr := Get()
+				So(newErr, ShouldBeNil)
+				So(newCfg, ShouldResemble, cfg)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Removed:

- DATASET_API_AUTH_TOKEN
- FILTER_API_AUTH_TOKEN
- CODE_LIST_API
- FILTER_API_URL
- DATASET_API_URL
- HIERARCHY_API_URL
- SEARCH_API_URL

Added tests for defaults.
Updated readme table.
Sorted env vars alphabetically.

### How to review

Check haven't removed anything I shouldn't have. 

### Who can review

Not me. 