### PR TITLE
Update sixteens hash to fix feedback api value error

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -31,7 +31,7 @@ const (
 	latest          = "latest"
 	list            = "list"
 	single          = "single"
-	sixteensVersion = "bc2c02c"
+	sixteensVersion = "2c5867a"
 	strRange        = "range"
 	strTime         = "time"
 	strType         = "type"


### PR DESCRIPTION
### What

- Update sixteens hash to fix console error for feedback api value
  - Fix error for `/dimensions` page
![image](https://github.com/user-attachments/assets/3f4633d2-024c-445b-88fd-f2b2fee7a3c2)

### How to review

- Check hash matches latest sixteens release
- Run with latest `sixteens`
- Check http://localhost:20001/filters/00dab720-0062-45ec-bc03-c6d5bd381d78/dimensions
- Check dev tools that error is gone

### Who can review

!Me
