### PR TITLE
Move dataset filter check logic from dp-frontend-router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,26 +8,28 @@ import (
 
 // Config represents service configuration for dp-frontend-filter-dataset-controller
 type Config struct {
-	APIRouterURL               string        `envconfig:"API_ROUTER_URL"`
-	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
-	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
-	BindAddr                   string        `envconfig:"BIND_ADDR"`
-	Debug                      bool          `envconfig:"DEBUG"`
-	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
-	EnableDatasetPreview       bool          `envconfig:"ENABLE_DATASET_PREVIEW"`
-	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
-	FeedbackAPIURL             string        `envconfig:"FEEDBACK_API_URL"`
-	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	MaxDatasetOptions          int           `envconfig:"MAX_DATASET_OPTIONS"`
-	PatternLibraryAssetsPath   string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
-	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
-	SearchAPIAuthToken         string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
-	SiteDomain                 string        `envconfig:"SITE_DOMAIN"`
-	OTExporterOTLPEndpoint     string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	OTServiceName              string        `envconfig:"OTEL_SERVICE_NAME"`
-	OTBatchTimeout             time.Duration `envconfig:"OTEL_BATCH_TIMEOUT"`
+	APIRouterURL                      	string        	`envconfig:"API_ROUTER_URL"`
+	BatchMaxWorkers                   	int           	`envconfig:"BATCH_MAX_WORKERS"`
+	BatchSizeLimit                    	int           	`envconfig:"BATCH_SIZE_LIMIT"`
+	BindAddr                          	string        	`envconfig:"BIND_ADDR"`
+	Debug                             	bool          	`envconfig:"DEBUG"`
+	DownloadServiceURL                	string        	`envconfig:"DOWNLOAD_SERVICE_URL"`
+	EnableDatasetPreview              	bool          	`envconfig:"ENABLE_DATASET_PREVIEW"`
+	EnableProfiler                    	bool          	`envconfig:"ENABLE_PROFILER"`
+	FeedbackAPIURL                    	string        	`envconfig:"FEEDBACK_API_URL"`
+	FilterFlexDatasetServiceURL       	string        	`envconfig:"FILTER_FLEX_DATASET_SERVICE_URL"`
+	FrontendFilterDatasetControllerURL	string        	`envconfig:"FRONTEND_FILTER_DATASET_CONTROLLER_URL"`
+	GracefulShutdownTimeout           	time.Duration 	`envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	HealthCheckCriticalTimeout        	time.Duration 	`envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	HealthCheckInterval               	time.Duration 	`envconfig:"HEALTHCHECK_INTERVAL"`
+	MaxDatasetOptions                 	int           	`envconfig:"MAX_DATASET_OPTIONS"`
+	PatternLibraryAssetsPath          	string        	`envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
+	PprofToken                        	string        	`envconfig:"PPROF_TOKEN" json:"-"`
+	SearchAPIAuthToken                	string        	`envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
+	SiteDomain                        	string        	`envconfig:"SITE_DOMAIN"`
+	OTExporterOTLPEndpoint            	string        	`envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	OTServiceName                     	string        	`envconfig:"OTEL_SERVICE_NAME"`
+	OTBatchTimeout                    	time.Duration 	`envconfig:"OTEL_BATCH_TIMEOUT"`
 }
 
 var cfg *Config
@@ -55,23 +57,25 @@ func get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		APIRouterURL:               "http://localhost:23200/v1",
-		BatchMaxWorkers:            100,
-		BatchSizeLimit:             1000,
-		BindAddr:                   "localhost:20001",
-		Debug:                      false,
-		DownloadServiceURL:         "http://localhost:23600",
-		EnableDatasetPreview:       false,
-		EnableProfiler:             false,
-		FeedbackAPIURL:             "http://localhost:23200/v1/feedback",
-		GracefulShutdownTimeout:    5 * time.Second,
-		HealthCheckCriticalTimeout: 90 * time.Second,
-		HealthCheckInterval:        30 * time.Second,
-		MaxDatasetOptions:          200,
-		SiteDomain:                 "localhost",
-		OTExporterOTLPEndpoint:     "localhost:4317",
-		OTServiceName:              "dp-frontend-filter-dataset-controller",
-		OTBatchTimeout:             5 * time.Second,
+		APIRouterURL:                      	"http://localhost:23200/v1",
+		BatchMaxWorkers:                   	100,
+		BatchSizeLimit:                    	1000,
+		BindAddr:                          	"localhost:20001",
+		Debug:                             	false,
+		DownloadServiceURL:                	"http://localhost:23600",
+		EnableDatasetPreview:              	false,
+		EnableProfiler:                    	false,
+		FeedbackAPIURL:                    	"http://localhost:23200/v1/feedback",
+		FilterFlexDatasetServiceURL:       	"http://localhost:27100",
+		FrontendFilterDatasetControllerURL:	"http://localhost:20001",
+		GracefulShutdownTimeout:           	5 * time.Second,
+		HealthCheckCriticalTimeout:        	90 * time.Second,
+		HealthCheckInterval:               	30 * time.Second,
+		MaxDatasetOptions:                 	200,
+		SiteDomain:                        	"localhost",
+		OTExporterOTLPEndpoint:            	"localhost:4317",
+		OTServiceName:                     	"dp-frontend-filter-dataset-controller",
+		OTBatchTimeout:                    	5 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -8,28 +8,28 @@ import (
 
 // Config represents service configuration for dp-frontend-filter-dataset-controller
 type Config struct {
-	APIRouterURL                      	string        	`envconfig:"API_ROUTER_URL"`
-	BatchMaxWorkers                   	int           	`envconfig:"BATCH_MAX_WORKERS"`
-	BatchSizeLimit                    	int           	`envconfig:"BATCH_SIZE_LIMIT"`
-	BindAddr                          	string        	`envconfig:"BIND_ADDR"`
-	Debug                             	bool          	`envconfig:"DEBUG"`
-	DownloadServiceURL                	string        	`envconfig:"DOWNLOAD_SERVICE_URL"`
-	EnableDatasetPreview              	bool          	`envconfig:"ENABLE_DATASET_PREVIEW"`
-	EnableProfiler                    	bool          	`envconfig:"ENABLE_PROFILER"`
-	FeedbackAPIURL                    	string        	`envconfig:"FEEDBACK_API_URL"`
-	FilterFlexDatasetServiceURL       	string        	`envconfig:"FILTER_FLEX_DATASET_SERVICE_URL"`
-	FrontendFilterDatasetControllerURL	string        	`envconfig:"FRONTEND_FILTER_DATASET_CONTROLLER_URL"`
-	GracefulShutdownTimeout           	time.Duration 	`envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckCriticalTimeout        	time.Duration 	`envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	HealthCheckInterval               	time.Duration 	`envconfig:"HEALTHCHECK_INTERVAL"`
-	MaxDatasetOptions                 	int           	`envconfig:"MAX_DATASET_OPTIONS"`
-	PatternLibraryAssetsPath          	string        	`envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
-	PprofToken                        	string        	`envconfig:"PPROF_TOKEN" json:"-"`
-	SearchAPIAuthToken                	string        	`envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
-	SiteDomain                        	string        	`envconfig:"SITE_DOMAIN"`
-	OTExporterOTLPEndpoint            	string        	`envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	OTServiceName                     	string        	`envconfig:"OTEL_SERVICE_NAME"`
-	OTBatchTimeout                    	time.Duration 	`envconfig:"OTEL_BATCH_TIMEOUT"`
+	APIRouterURL                       string        `envconfig:"API_ROUTER_URL"`
+	BatchMaxWorkers                    int           `envconfig:"BATCH_MAX_WORKERS"`
+	BatchSizeLimit                     int           `envconfig:"BATCH_SIZE_LIMIT"`
+	BindAddr                           string        `envconfig:"BIND_ADDR"`
+	Debug                              bool          `envconfig:"DEBUG"`
+	DownloadServiceURL                 string        `envconfig:"DOWNLOAD_SERVICE_URL"`
+	EnableDatasetPreview               bool          `envconfig:"ENABLE_DATASET_PREVIEW"`
+	EnableProfiler                     bool          `envconfig:"ENABLE_PROFILER"`
+	FeedbackAPIURL                     string        `envconfig:"FEEDBACK_API_URL"`
+	FilterFlexDatasetServiceURL        string        `envconfig:"FILTER_FLEX_DATASET_SERVICE_URL"`
+	FrontendFilterDatasetControllerURL string        `envconfig:"FRONTEND_FILTER_DATASET_CONTROLLER_URL"`
+	GracefulShutdownTimeout            time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	HealthCheckCriticalTimeout         time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	HealthCheckInterval                time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	MaxDatasetOptions                  int           `envconfig:"MAX_DATASET_OPTIONS"`
+	PatternLibraryAssetsPath           string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
+	PprofToken                         string        `envconfig:"PPROF_TOKEN" json:"-"`
+	SearchAPIAuthToken                 string        `envconfig:"SEARCH_API_AUTH_TOKEN"  json:"-"`
+	SiteDomain                         string        `envconfig:"SITE_DOMAIN"`
+	OTExporterOTLPEndpoint             string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	OTServiceName                      string        `envconfig:"OTEL_SERVICE_NAME"`
+	OTBatchTimeout                     time.Duration `envconfig:"OTEL_BATCH_TIMEOUT"`
 }
 
 var cfg *Config
@@ -57,25 +57,25 @@ func get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		APIRouterURL:                      	"http://localhost:23200/v1",
-		BatchMaxWorkers:                   	100,
-		BatchSizeLimit:                    	1000,
-		BindAddr:                          	"localhost:20001",
-		Debug:                             	false,
-		DownloadServiceURL:                	"http://localhost:23600",
-		EnableDatasetPreview:              	false,
-		EnableProfiler:                    	false,
-		FeedbackAPIURL:                    	"http://localhost:23200/v1/feedback",
-		FilterFlexDatasetServiceURL:       	"http://localhost:27100",
-		FrontendFilterDatasetControllerURL:	"http://localhost:20001",
-		GracefulShutdownTimeout:           	5 * time.Second,
-		HealthCheckCriticalTimeout:        	90 * time.Second,
-		HealthCheckInterval:               	30 * time.Second,
-		MaxDatasetOptions:                 	200,
-		SiteDomain:                        	"localhost",
-		OTExporterOTLPEndpoint:            	"localhost:4317",
-		OTServiceName:                     	"dp-frontend-filter-dataset-controller",
-		OTBatchTimeout:                    	5 * time.Second,
+		APIRouterURL:                       "http://localhost:23200/v1",
+		BatchMaxWorkers:                    100,
+		BatchSizeLimit:                     1000,
+		BindAddr:                           "localhost:20001",
+		Debug:                              false,
+		DownloadServiceURL:                 "http://localhost:23600",
+		EnableDatasetPreview:               false,
+		EnableProfiler:                     false,
+		FeedbackAPIURL:                     "http://localhost:23200/v1/feedback",
+		FilterFlexDatasetServiceURL:        "http://localhost:27100",
+		FrontendFilterDatasetControllerURL: "http://localhost:20001",
+		GracefulShutdownTimeout:            5 * time.Second,
+		HealthCheckCriticalTimeout:         90 * time.Second,
+		HealthCheckInterval:                30 * time.Second,
+		MaxDatasetOptions:                  200,
+		SiteDomain:                         "localhost",
+		OTExporterOTLPEndpoint:             "localhost:4317",
+		OTServiceName:                      "dp-frontend-filter-dataset-controller",
+		OTBatchTimeout:                     5 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.266.0
 	github.com/ONSdigital/dp-cookies v0.6.0
+	github.com/ONSdigital/dp-frontend-router v1.102.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.3.0
 	github.com/ONSdigital/dp-otel-go v0.0.8
@@ -18,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
+	go.opentelemetry.io/otel v1.36.0
 	golang.org/x/text v0.26.0
 )
 
@@ -51,7 +53,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.36.0 // indirect
-	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,12 +19,12 @@ require (
 	github.com/smartystreets/goconvey v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
-	go.opentelemetry.io/otel v1.36.0
 	golang.org/x/text v0.26.0
 )
 
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
+	github.com/ONSdigital/dp-dataset-api v1.81.2 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -45,14 +45,17 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/smarty/assertions v1.16.0 // indirect
 	github.com/unrolled/render v1.7.0 // indirect
+	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/propagators/autoprop v0.61.0 // indirect
 	go.opentelemetry.io/contrib/propagators/aws v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.36.0 // indirect
+	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.266.0 h1:NQbu+x2Q7ZhrjGKvN73qVxG/n
 github.com/ONSdigital/dp-api-clients-go/v2 v2.266.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-cookies v0.6.0 h1:bYiV/M0W7ufn7bIJf2cYjY2vtMUrdU0uLt7mYP3TV4c=
 github.com/ONSdigital/dp-cookies v0.6.0/go.mod h1:YQyEcsQJQcndQFraHt6YawJGOccsm6wJv+31f9jaKfI=
+github.com/ONSdigital/dp-dataset-api v1.81.2 h1:Cmc4pBpz8EqUFmq9DueBe39vNmLbxZiAY/luKoUzPAo=
+github.com/ONSdigital/dp-dataset-api v1.81.2/go.mod h1:ttZUnRdOa0XF9ayIR2ha/V4eq18Ht0Pyo2UO5CND/sI=
 github.com/ONSdigital/dp-frontend-router v1.102.0 h1:Ae6qjK3eS/Kv4U7KSNnMXoC8PqIm/g7i5mVr6NRExd0=
 github.com/ONSdigital/dp-frontend-router v1.102.0/go.mod h1:FJ1hEojxWISsyoxAxpPnQ7BaDx8niqyeLJfLB0nj7BQ=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
@@ -77,6 +79,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
@@ -86,6 +90,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/unrolled/render v1.7.0 h1:1yke01/tZiZpiXfUG+zqB+6fq3G4I+KDmnh0EhPq7So=
 github.com/unrolled/render v1.7.0/go.mod h1:LwQSeDhjml8NLjIO9GJO1/1qpFJxtfVIpzxXKjfVkoI=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
+go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.61.0 h1:4biLRyCkHnLDYE56ry1Q33POTcthaCZevuPkat6zC3o=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.266.0 h1:NQbu+x2Q7ZhrjGKvN73qVxG/n
 github.com/ONSdigital/dp-api-clients-go/v2 v2.266.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-cookies v0.6.0 h1:bYiV/M0W7ufn7bIJf2cYjY2vtMUrdU0uLt7mYP3TV4c=
 github.com/ONSdigital/dp-cookies v0.6.0/go.mod h1:YQyEcsQJQcndQFraHt6YawJGOccsm6wJv+31f9jaKfI=
+github.com/ONSdigital/dp-frontend-router v1.102.0 h1:Ae6qjK3eS/Kv4U7KSNnMXoC8PqIm/g7i5mVr6NRExd0=
+github.com/ONSdigital/dp-frontend-router v1.102.0/go.mod h1:FJ1hEojxWISsyoxAxpPnQ7BaDx8niqyeLJfLB0nj7BQ=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85cG2UNQw=

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -9,11 +9,13 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/hierarchy"
 	"github.com/ONSdigital/dp-api-clients-go/v2/search"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	dpDatasetApiModels "github.com/ONSdigital/dp-dataset-api/models"
+	dpDatasetApiSdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-renderer/v2/model"
 )
 
-//go:generate mockgen -source=clients.go -destination=mock_clients.go -package=handlers github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers FilterClient,DatasetClient,HierarchyClient,SearchClient,Renderer
+//go:generate mockgen -source=clients.go -destination=mock_clients.go -package=handlers github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers FilterClient,DatasetClient,DatasetAPISdkClient,HierarchyClient,SearchClient,Renderer
 
 // ClientError implements error interface with additional code method
 type ClientError interface {
@@ -53,6 +55,10 @@ type DatasetClient interface {
 	GetOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize, maxWorkers int) (err error)
 	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version string) (m dataset.Metadata, err error)
 	GetEdition(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID, edition string) (m dataset.Edition, err error)
+}
+
+type DatasetAPISdkClient interface {
+	GetDataset(ctx context.Context, headers dpDatasetApiSdk.Headers, collectionID, datasetID string) (m dpDatasetApiModels.Dataset, err error)
 }
 
 // HierarchyClient contains methods expected for a hierarchy client

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -34,6 +34,13 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetAPISdkClient, filter
 			return
 		}
 
+		// Obtain access_token from cookie
+		c, err := r.Cookie(`access_token`)
+		if err == nil && c.Value != "" {
+			userAuthToken = c.Value
+			log.Info(r.Context(), "obtained access_token Cookie")
+		}
+
 		filterModel, _, err := f.GetJobState(
 			ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID,
 		)

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -16,11 +16,10 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filt
 		ctx := r.Context()
 		vars := mux.Vars(r)
 
-		userAuthToken := "" 
+		userAuthToken := ""
 		serviceAuthToken := ""
 		collectionID := ""
 		downloadServiceToken := ""
-
 
 		filterID := vars["filterID"]
 		if filterID == "" {

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -21,6 +21,13 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetAPISdkClient, filter
 		collectionID := ""
 		downloadServiceToken := ""
 
+		// Obtain access_token from cookie
+		c, err := r.Cookie(`access_token`)
+		if err == nil && c.Value != "" {
+			userAuthToken = c.Value
+			log.Info(r.Context(), "obtained access_token Cookie")
+		}
+
 		headers := dpDatasetApiSdk.Headers{
 			CollectionID:         collectionID,
 			DownloadServiceToken: downloadServiceToken,
@@ -32,13 +39,6 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetAPISdkClient, filter
 		if filterID == "" {
 			http.Error(w, "missing filter ID", http.StatusBadRequest)
 			return
-		}
-
-		// Obtain access_token from cookie
-		c, err := r.Cookie(`access_token`)
-		if err == nil && c.Value != "" {
-			userAuthToken = c.Value
-			log.Info(r.Context(), "obtained access_token Cookie")
 		}
 
 		filterModel, _, err := f.GetJobState(

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/gorilla/mux"
+)
+
+// Handler is middleware that a accepts a filter and dataset client that returns either the filter or filterFlex handler dependent on the type of dataset
+// FilterPageHandler handles requests to /filters/{filterID}
+func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filterFlex http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+
+		userAuthToken := "" 
+		serviceAuthToken := ""
+		collectionID := ""
+		downloadServiceToken := ""
+
+
+		filterID := vars["filterID"]
+		if filterID == "" {
+			http.Error(w, "missing filter ID", http.StatusBadRequest)
+			return
+		}
+
+		filterModel, _, err := f.GetJobState(
+			ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID,
+		)
+		if err != nil {
+			log.Error(ctx, "failed to get filter job state", err)
+			http.Error(w, "failed to get filter", http.StatusInternalServerError)
+			return
+		}
+
+		datasetDetails, err := datasetClient.Get(ctx, userAuthToken, serviceAuthToken, collectionID, filterModel.Dataset.DatasetID)
+		if err != nil {
+			log.Error(ctx, "failed to get dataset details", err)
+			http.Error(w, "failed to get dataset", http.StatusInternalServerError)
+			return
+		}
+
+		if strings.Contains(datasetDetails.Type, "cantabular") {
+			// Redirect to dp-frontend-filter-flex-dataset and continue filter-flex journey
+			filterFlex.ServeHTTP(w, r)
+			return
+		}
+
+		// If CMD type, the CMD filter journey works as it currently does i.e. to frontend-filter-dataset-controller
+		filter.ServeHTTP(w, r)
+	}
+}
+
+func ReturnSecondSegmentFromPath(path string) (secondSegment string, err error) {
+	subs := strings.Split(path, "/")
+	if len(subs) < 3 {
+		err = fmt.Errorf("unable to extract secondSegment from path: %s", path)
+		return
+	}
+	return subs[2], nil
+}

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -4,13 +4,14 @@ import (
 	"net/http"
 	"strings"
 
+	dpDatasetApiSdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 )
 
 // Handler is middleware that a accepts a filter and dataset client that returns either the filter or filterFlex handler dependent on the type of dataset
 // FilterPageHandler handles requests to /filters/{filterID}
-func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filterFlex http.Handler) http.HandlerFunc {
+func FilterPageHandler(f FilterClient, datasetClient DatasetAPISdkClient, filter, filterFlex http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		vars := mux.Vars(r)
@@ -19,6 +20,13 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filt
 		serviceAuthToken := ""
 		collectionID := ""
 		downloadServiceToken := ""
+
+		headers := dpDatasetApiSdk.Headers{
+			CollectionID:         collectionID,
+			DownloadServiceToken: downloadServiceToken,
+			ServiceToken:         serviceAuthToken,
+			UserAccessToken:      userAuthToken,
+		}
 
 		filterID := vars["filterID"]
 		if filterID == "" {
@@ -35,7 +43,7 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filt
 			return
 		}
 
-		datasetDetails, err := datasetClient.Get(ctx, userAuthToken, serviceAuthToken, collectionID, filterModel.Dataset.DatasetID)
+		datasetDetails, err := datasetClient.GetDataset(ctx, headers, collectionID, filterModel.Dataset.DatasetID)
 		if err != nil {
 			log.Error(ctx, "failed to get dataset details", err)
 			http.Error(w, "failed to get dataset", http.StatusInternalServerError)

--- a/handlers/filter_page.go
+++ b/handlers/filter_page.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -52,13 +51,4 @@ func FilterPageHandler(f FilterClient, datasetClient DatasetClient, filter, filt
 		// If CMD type, the CMD filter journey works as it currently does i.e. to frontend-filter-dataset-controller
 		filter.ServeHTTP(w, r)
 	}
-}
-
-func ReturnSecondSegmentFromPath(path string) (secondSegment string, err error) {
-	subs := strings.Split(path, "/")
-	if len(subs) < 3 {
-		err = fmt.Errorf("unable to extract secondSegment from path: %s", path)
-		return
-	}
-	return subs[2], nil
 }

--- a/handlers/filter_page_test.go
+++ b/handlers/filter_page_test.go
@@ -12,6 +12,7 @@ import (
 
 	dpApiClientsGoDataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	dpDatasetApiSdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	"github.com/ONSdigital/dp-frontend-router/router/routertest"
 )
 
@@ -27,7 +28,7 @@ func TestFilterPageHandler(t *testing.T) {
 
 	mockContext := gomock.Any()
 	mockFilterClient := NewMockFilterClient(mockCtrl)
-	mockDatasetClient := NewMockDatasetClient(mockCtrl)
+	mockDatasetClient := NewMockDatasetAPISdkClient(mockCtrl)
 
 	mockFilterModel := &filter.Model{
 		Dataset: filter.Dataset{
@@ -36,9 +37,16 @@ func TestFilterPageHandler(t *testing.T) {
 	}
 
 	collectionID := ""
-	userAuthToken := ""
-	serviceAuthToken := ""
 	downloadServiceToken := ""
+	serviceAuthToken := ""
+	userAuthToken := ""
+	
+	headers := dpDatasetApiSdk.Headers{
+		CollectionID:         collectionID,
+		DownloadServiceToken: downloadServiceToken,
+		ServiceToken:         serviceAuthToken,
+		UserAccessToken:      userAuthToken,
+	}
 
 	Convey("Given a FilterPageHandler", t, func() {
 		Convey("When filterID is missing", func() {
@@ -98,8 +106,8 @@ func TestFilterPageHandler(t *testing.T) {
 				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
 			).Return(*mockFilterModel, "", nil)
 
-			mockDatasetClient.EXPECT().Get(
-				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			mockDatasetClient.EXPECT().GetDataset(
+				mockContext, headers, collectionID, "123",
 			).Return(dpApiClientsGoDataset.DatasetDetails{}, errors.New("dataset error"))
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)
@@ -129,8 +137,8 @@ func TestFilterPageHandler(t *testing.T) {
 				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
 			).Return(*mockFilterModel, "", nil)
 
-			mockDatasetClient.EXPECT().Get(
-				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			mockDatasetClient.EXPECT().GetDataset(
+				mockContext, headers, collectionID, "123",
 			).Return(datasetDetails, nil)
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)
@@ -169,8 +177,8 @@ func TestFilterPageHandler(t *testing.T) {
 				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
 			).Return(*mockFilterModel, "", nil)
 
-			mockDatasetClient.EXPECT().Get(
-				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			mockDatasetClient.EXPECT().GetDataset(
+				mockContext, headers, collectionID, "123",
 			).Return(datasetDetails, nil)
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)

--- a/handlers/filter_page_test.go
+++ b/handlers/filter_page_test.go
@@ -12,7 +12,6 @@ import (
 
 	dpApiClientsGoDataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
-	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-router/router/routertest"
 )
 
@@ -27,15 +26,8 @@ func TestFilterPageHandler(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockContext := gomock.Any()
-	mockConfig := config.Config{
-		FilterFlexDatasetServiceURL:        "http://localhost:27100",
-		FrontendFilterDatasetControllerURL: "http://localhost:20001",
-	}
-
 	mockFilterClient := NewMockFilterClient(mockCtrl)
 	mockDatasetClient := NewMockDatasetClient(mockCtrl)
-	filterHandler := NewHandlerMock()
-	filterFlexHandler := NewHandlerMock()
 
 	mockFilterModel := &filter.Model{
 		Dataset: filter.Dataset{
@@ -49,12 +41,9 @@ func TestFilterPageHandler(t *testing.T) {
 	downloadServiceToken := ""
 
 	Convey("Given a FilterPageHandler", t, func() {
-		handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
-		router := mux.NewRouter()
-		router.HandleFunc("/filters/{filterID}/dimensions", handler)
-		router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
-
 		Convey("When filterID is missing", func() {
+			filterHandler := NewHandlerMock()
+			filterFlexHandler := NewHandlerMock()
 			mockRequestWriter := httptest.NewRecorder()
 			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/missing-filter-id/dimensions", http.NoBody)
 
@@ -70,7 +59,15 @@ func TestFilterPageHandler(t *testing.T) {
 			})
 		})
 
-		Convey("If GetJobState returns error", func() {
+		Convey("When GetJobState returns error", func() {
+			filterHandler := NewHandlerMock()
+			filterFlexHandler := NewHandlerMock()
+
+			handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+			router := mux.NewRouter()
+			router.HandleFunc("/filters/{filterID}/dimensions", handler)
+			router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
+
 			mockRequestWriter := httptest.NewRecorder()
 			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
 
@@ -85,9 +82,17 @@ func TestFilterPageHandler(t *testing.T) {
 			})
 		})
 
-		Convey("If error is returned fetching dataset", func() {
+		Convey("When error is returned fetching dataset", func() {
 			mockRequestWriter := httptest.NewRecorder()
 			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
+
+			filterHandler := NewHandlerMock()
+			filterFlexHandler := NewHandlerMock()
+
+			router := mux.NewRouter()
+			handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+			router.HandleFunc("/filters/{filterID}/dimensions", handler)
+			router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
 
 			mockFilterClient.EXPECT().GetJobState(
 				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
@@ -104,9 +109,17 @@ func TestFilterPageHandler(t *testing.T) {
 			})
 		})
 
-		Convey("If dataset is 'cantabular' type", func() {
+		Convey("When dataset is 'cantabular' type", func() {
 			mockRequestWriter := httptest.NewRecorder()
 			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions/ltla", http.NoBody)
+
+			filterHandler := NewHandlerMock()
+			filterFlexHandler := NewHandlerMock()
+
+			router := mux.NewRouter()
+			handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+			router.HandleFunc("/filters/{filterID}/dimensions", handler)
+			router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
 
 			datasetDetails := dpApiClientsGoDataset.DatasetDetails{
 				Type: "cantabular",
@@ -122,19 +135,31 @@ func TestFilterPageHandler(t *testing.T) {
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)
 
-			Convey("Then the status code is 307", func() {
-				So(mockRequestWriter.Code, ShouldEqual, http.StatusTemporaryRedirect)
+			Convey("Then the status code is 200", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusOK)
 			})
 
-			// TODO: look at other redirects used in this repo
-			Convey("Then a redirect is made to FilterFlexDatasetServiceURL ", func() {
-				So(mockRequestWriter.Header().Get("Location"), ShouldStartWith, mockConfig.FilterFlexDatasetServiceURL)
+			Convey("Then the request is sent to Filter Flex Dataset Service", func() {
+				So(len(filterFlexHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(filterFlexHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, "/filters/123/dimensions/ltla")
+			})
+
+			Convey("Then Filter Dataset Service was not called", func() {
+				So(len(filterHandler.ServeHTTPCalls()), ShouldEqual, 0)
 			})
 		})
 
-		Convey("If dataset is not 'cantabular' type", func() {
+		Convey("When dataset is not 'cantabular' type", func() {
+			filterHandler := NewHandlerMock()
+			filterFlexHandler := NewHandlerMock()
+
 			mockRequestWriter := httptest.NewRecorder()
 			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
+
+			router := mux.NewRouter()
+			handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+			router.HandleFunc("/filters/{filterID}/dimensions", handler)
+			router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
 
 			datasetDetails := dpApiClientsGoDataset.DatasetDetails{
 				Type: "cmd",
@@ -150,13 +175,17 @@ func TestFilterPageHandler(t *testing.T) {
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)
 
-			Convey("Then the status code is 307", func() {
-				So(mockRequestWriter.Code, ShouldEqual, http.StatusTemporaryRedirect)
+			Convey("Then the status code is 200", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusOK)
 			})
 
-			// TODO: look at other redirects used in this repo
-			Convey("Then a redirect is made to FrontendFilterDatasetControllerURL ", func() {
-				So(mockRequestWriter.Header().Get("Location"), ShouldStartWith, mockConfig.FrontendFilterDatasetControllerURL)
+			Convey("Then the request is sent to Filter Flex Dataset Service", func() {
+				So(len(filterHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(filterHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, "/filters/123/dimensions")
+			})
+
+			Convey("Then Filter Dataset Service was not called", func() {
+				So(len(filterFlexHandler.ServeHTTPCalls()), ShouldEqual, 0)
 			})
 		})
 	})

--- a/handlers/filter_page_test.go
+++ b/handlers/filter_page_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+
+	dpApiClientsGoDataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
+	"github.com/ONSdigital/dp-frontend-router/router/routertest"
+)
+
+func NewHandlerMock() *routertest.HandlerMock {
+	return &routertest.HandlerMock{
+		ServeHTTPFunc: func(in1 http.ResponseWriter, in2 *http.Request) {},
+	}
+}
+
+func TestFilterPageHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockContext := gomock.Any()
+	mockConfig := config.Config{
+		FilterFlexDatasetServiceURL:        "http://localhost:27100",
+		FrontendFilterDatasetControllerURL: "http://localhost:20001",
+	}
+
+	mockFilterClient := NewMockFilterClient(mockCtrl)
+	mockDatasetClient := NewMockDatasetClient(mockCtrl)
+	filterHandler := NewHandlerMock()
+	filterFlexHandler := NewHandlerMock()
+
+	mockFilterModel := &filter.Model{
+		Dataset: filter.Dataset{
+			DatasetID: "123",
+		},
+	}
+
+	collectionID := ""
+	userAuthToken := ""
+	serviceAuthToken := ""
+	downloadServiceToken := ""
+
+	Convey("Given a FilterPageHandler", t, func() {
+		handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+		router := mux.NewRouter()
+		router.HandleFunc("/filters/{filterID}/dimensions", handler)
+		router.HandleFunc("/filters/{filterID}/dimensions/{dimension}", handler)
+
+		Convey("When filterID is missing", func() {
+			mockRequestWriter := httptest.NewRecorder()
+			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/missing-filter-id/dimensions", http.NoBody)
+
+			// Override behaviour — simulate the missing filter id
+			vars := map[string]string{"filterID": ""}
+			mockRequest = mux.SetURLVars(mockRequest, vars)
+
+			handler := FilterPageHandler(mockFilterClient, mockDatasetClient, filterHandler, filterFlexHandler)
+			handler(mockRequestWriter, mockRequest)
+
+			Convey("Then the status code is 400", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusBadRequest)
+			})
+		})
+
+		Convey("If GetJobState returns error", func() {
+			mockRequestWriter := httptest.NewRecorder()
+			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
+
+			mockFilterClient.EXPECT().GetJobState(
+				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
+			).Return(filter.Model{}, "", errors.New("some error"))
+
+			router.ServeHTTP(mockRequestWriter, mockRequest)
+
+			Convey("Then the status code is 500", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
+		Convey("If error is returned fetching dataset", func() {
+			mockRequestWriter := httptest.NewRecorder()
+			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
+
+			mockFilterClient.EXPECT().GetJobState(
+				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
+			).Return(*mockFilterModel, "", nil)
+
+			mockDatasetClient.EXPECT().Get(
+				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			).Return(dpApiClientsGoDataset.DatasetDetails{}, errors.New("dataset error"))
+
+			router.ServeHTTP(mockRequestWriter, mockRequest)
+
+			Convey("Then the status code is 500", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
+		Convey("If dataset is 'cantabular' type", func() {
+			mockRequestWriter := httptest.NewRecorder()
+			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions/ltla", http.NoBody)
+
+			datasetDetails := dpApiClientsGoDataset.DatasetDetails{
+				Type: "cantabular",
+			}
+
+			mockFilterClient.EXPECT().GetJobState(
+				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
+			).Return(*mockFilterModel, "", nil)
+
+			mockDatasetClient.EXPECT().Get(
+				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			).Return(datasetDetails, nil)
+
+			router.ServeHTTP(mockRequestWriter, mockRequest)
+
+			Convey("Then the status code is 307", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusTemporaryRedirect)
+			})
+
+			// TODO: look at other redirects used in this repo
+			Convey("Then a redirect is made to FilterFlexDatasetServiceURL ", func() {
+				So(mockRequestWriter.Header().Get("Location"), ShouldStartWith, mockConfig.FilterFlexDatasetServiceURL)
+			})
+		})
+
+		Convey("If dataset is not 'cantabular' type", func() {
+			mockRequestWriter := httptest.NewRecorder()
+			mockRequest := httptest.NewRequest(http.MethodGet, "/filters/123/dimensions", http.NoBody)
+
+			datasetDetails := dpApiClientsGoDataset.DatasetDetails{
+				Type: "cmd",
+			}
+
+			mockFilterClient.EXPECT().GetJobState(
+				mockContext, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, "123",
+			).Return(*mockFilterModel, "", nil)
+
+			mockDatasetClient.EXPECT().Get(
+				mockContext, userAuthToken, serviceAuthToken, collectionID, "123",
+			).Return(datasetDetails, nil)
+
+			router.ServeHTTP(mockRequestWriter, mockRequest)
+
+			Convey("Then the status code is 307", func() {
+				So(mockRequestWriter.Code, ShouldEqual, http.StatusTemporaryRedirect)
+			})
+
+			// TODO: look at other redirects used in this repo
+			Convey("Then a redirect is made to FrontendFilterDatasetControllerURL ", func() {
+				So(mockRequestWriter.Header().Get("Location"), ShouldStartWith, mockConfig.FrontendFilterDatasetControllerURL)
+			})
+		})
+	})
+}

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -14,6 +14,8 @@ import (
 	hierarchy "github.com/ONSdigital/dp-api-clients-go/v2/hierarchy"
 	search "github.com/ONSdigital/dp-api-clients-go/v2/search"
 	zebedee "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	models "github.com/ONSdigital/dp-dataset-api/models"
+	sdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	healthcheck "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	model "github.com/ONSdigital/dp-renderer/v2/model"
 	gomock "github.com/golang/mock/gomock"
@@ -508,6 +510,44 @@ func (m *MockDatasetClient) GetVersionMetadata(ctx context.Context, userAuthToke
 func (mr *MockDatasetClientMockRecorder) GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionMetadata", reflect.TypeOf((*MockDatasetClient)(nil).GetVersionMetadata), ctx, userAuthToken, serviceAuthToken, collectionID, datasetID, edition, version)
+}
+
+// MockDatasetAPISdkClient is a mock of DatasetAPISdkClient interface.
+type MockDatasetAPISdkClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockDatasetAPISdkClientMockRecorder
+}
+
+// MockDatasetAPISdkClientMockRecorder is the mock recorder for MockDatasetAPISdkClient.
+type MockDatasetAPISdkClientMockRecorder struct {
+	mock *MockDatasetAPISdkClient
+}
+
+// NewMockDatasetAPISdkClient creates a new mock instance.
+func NewMockDatasetAPISdkClient(ctrl *gomock.Controller) *MockDatasetAPISdkClient {
+	mock := &MockDatasetAPISdkClient{ctrl: ctrl}
+	mock.recorder = &MockDatasetAPISdkClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDatasetAPISdkClient) EXPECT() *MockDatasetAPISdkClientMockRecorder {
+	return m.recorder
+}
+
+// GetDataset mocks base method.
+func (m *MockDatasetAPISdkClient) GetDataset(ctx context.Context, headers sdk.Headers, collectionID, datasetID string) (models.Dataset, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataset", ctx, headers, collectionID, datasetID)
+	ret0, _ := ret[0].(models.Dataset)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDataset indicates an expected call of GetDataset.
+func (mr *MockDatasetAPISdkClientMockRecorder) GetDataset(ctx, headers, collectionID, datasetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataset", reflect.TypeOf((*MockDatasetAPISdkClient)(nil).GetDataset), ctx, headers, collectionID, datasetID)
 }
 
 // MockHierarchyClient is a mock of HierarchyClient interface.

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -3,11 +3,17 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/log.go/v2/log"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -63,4 +69,38 @@ func CheckAllDimensionsHaveAnOption(dims []filter.ModelDimension) (check bool, e
 func TitleCaseStr(input string) string {
 	c := cases.Title(language.English, cases.NoLower)
 	return c.String(input)
+}
+
+func ParseURL(ctx context.Context, cfgValue, configName string) (*url.URL, error) {
+	parsedURL, err := url.Parse(cfgValue)
+	if err != nil {
+		log.Fatal(ctx, "configuration value is invalid", err, log.Data{"config_name": configName, "value": cfgValue})
+		return nil, err
+	}
+	return parsedURL, nil
+}
+
+func CreateReverseProxy(proxyName string, proxyURL *url.URL) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
+	director := proxy.Director
+	proxy.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       180 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	proxy.Director = func(req *http.Request) {
+		log.Info(req.Context(), "proxying request", log.HTTP(req, 0, 0, nil, nil), log.Data{
+			"destination": proxyURL,
+			"proxy_name":  proxyName,
+		})
+		otel.GetTextMapPropagator().Inject(req.Context(), propagation.HeaderCarrier(req.Header))
+		director(req)
+	}
+	return proxy
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -3,17 +3,11 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"regexp"
-	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/log.go/v2/log"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -69,38 +63,4 @@ func CheckAllDimensionsHaveAnOption(dims []filter.ModelDimension) (check bool, e
 func TitleCaseStr(input string) string {
 	c := cases.Title(language.English, cases.NoLower)
 	return c.String(input)
-}
-
-func ParseURL(ctx context.Context, cfgValue, configName string) (*url.URL, error) {
-	parsedURL, err := url.Parse(cfgValue)
-	if err != nil {
-		log.Fatal(ctx, "configuration value is invalid", err, log.Data{"config_name": configName, "value": cfgValue})
-		return nil, err
-	}
-	return parsedURL, nil
-}
-
-func CreateReverseProxy(proxyName string, proxyURL *url.URL) http.Handler {
-	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-	director := proxy.Director
-	proxy.Transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       180 * time.Second,
-		TLSHandshakeTimeout:   5 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-	proxy.Director = func(req *http.Request) {
-		log.Info(req.Context(), "proxying request", log.HTTP(req, 0, 0, nil, nil), log.Data{
-			"destination": proxyURL,
-			"proxy_name":  proxyName,
-		})
-		otel.GetTextMapPropagator().Inject(req.Context(), propagation.HeaderCarrier(req.Header))
-		director(req)
-	}
-	return proxy
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -23,7 +23,7 @@ import (
 type Clients struct {
 	Filter             		*filter.Client
 	Dataset            		*dataset.Client
-	DatasetAPISdkClient 	handlers.DatasetAPISdkClient
+	DatasetAPISdkClient 	*handlers.DatasetAPISdkClient
 	Hierarchy          		*hierarchy.Client
 	HealthcheckHandler 		func(w http.ResponseWriter, req *http.Request)
 	Render             		*render.Render
@@ -46,7 +46,7 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 	filterHandler := dpRouterHelpers.CreateReverseProxy("filters", filterDatasetControllerURL)   // CMD
 	filterFlexHandler := dpRouterHelpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
 
-	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, clients.DatasetAPISdkClient, filterHandler, filterFlexHandler))
+	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, *clients.DatasetAPISdkClient, filterHandler, filterFlexHandler))
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(clients.HealthcheckHandler)
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
-	dpRouterHelpers "github.com/ONSdigital/dp-frontend-router/helpers"
 	render "github.com/ONSdigital/dp-renderer/v2"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -22,13 +21,14 @@ import (
 
 // Clients represents a list of clients
 type Clients struct {
-	Filter             *filter.Client
-	Dataset            *dataset.Client
-	Hierarchy          *hierarchy.Client
-	HealthcheckHandler func(w http.ResponseWriter, req *http.Request)
-	Render             *render.Render
-	Search             *search.Client
-	Zebedee            *zebedee.Client
+	Filter             		*filter.Client
+	Dataset            		*dataset.Client
+	DatasetAPISdkClient 	handlers.DatasetAPISdkClient
+	Hierarchy          		*hierarchy.Client
+	HealthcheckHandler 		func(w http.ResponseWriter, req *http.Request)
+	Render             		*render.Render
+	Search             		*search.Client
+	Zebedee            		*zebedee.Client
 }
 
 // Init initialises routes for the service
@@ -46,7 +46,7 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 	filterHandler := dpRouterHelpers.CreateReverseProxy("filters", filterDatasetControllerURL)   // CMD
 	filterFlexHandler := dpRouterHelpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
 
-	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, f.DatasetClient, filterHandler, filterFlexHandler))
+	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, clients.DatasetAPISdkClient, filterHandler, filterFlexHandler))
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(clients.HealthcheckHandler)
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/handlers"
 	"github.com/ONSdigital/dp-frontend-filter-dataset-controller/helpers"
+	dpRouterHelpers "github.com/ONSdigital/dp-frontend-router/helpers"
 	render "github.com/ONSdigital/dp-renderer/v2"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -40,10 +41,10 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 	f := handlers.NewFilter(clients.Render, clients.Filter, clients.Dataset,
 		clients.Hierarchy, clients.Search, clients.Zebedee, apiRouterVersion, cfg)
 
-	filterDatasetControllerURL, _ := helpers.ParseURL(ctx, cfg.FrontendFilterDatasetControllerURL, "FilterDatasetControllerURL")
-	filterFlexDatasetServiceURL, _ := helpers.ParseURL(ctx, cfg.FilterFlexDatasetServiceURL, "FilterFlexDatasetServiceURL")
-	filterHandler := helpers.CreateReverseProxy("filters", filterDatasetControllerURL)   // CMD
-	filterFlexHandler := helpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
+	filterDatasetControllerURL, _ := dpRouterHelpers.ParseURL(ctx, cfg.FrontendFilterDatasetControllerURL, "FilterDatasetControllerURL")
+	filterFlexDatasetServiceURL, _ := dpRouterHelpers.ParseURL(ctx, cfg.FilterFlexDatasetServiceURL, "FilterFlexDatasetServiceURL")
+	filterHandler := dpRouterHelpers.CreateReverseProxy("filters", filterDatasetControllerURL)   // CMD
+	filterFlexHandler := dpRouterHelpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
 
 	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, f.DatasetClient, filterHandler, filterFlexHandler))
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -39,6 +39,13 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 
 	f := handlers.NewFilter(clients.Render, clients.Filter, clients.Dataset,
 		clients.Hierarchy, clients.Search, clients.Zebedee, apiRouterVersion, cfg)
+	
+	filterDatasetControllerURL, _ := helpers.ParseURL(ctx, cfg.FrontendFilterDatasetControllerURL, "FilterDatasetControllerURL")
+	filterFlexDatasetServiceURL, _ := helpers.ParseURL(ctx, cfg.FilterFlexDatasetServiceURL, "FilterFlexDatasetServiceURL")
+	filterHandler := helpers.CreateReverseProxy("filters", filterDatasetControllerURL) // CMD
+	filterFlexHandler := helpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
+
+	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, f.DatasetClient, filterHandler, filterFlexHandler))
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(clients.HealthcheckHandler)
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -39,10 +39,10 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, clients *Clien
 
 	f := handlers.NewFilter(clients.Render, clients.Filter, clients.Dataset,
 		clients.Hierarchy, clients.Search, clients.Zebedee, apiRouterVersion, cfg)
-	
+
 	filterDatasetControllerURL, _ := helpers.ParseURL(ctx, cfg.FrontendFilterDatasetControllerURL, "FilterDatasetControllerURL")
 	filterFlexDatasetServiceURL, _ := helpers.ParseURL(ctx, cfg.FilterFlexDatasetServiceURL, "FilterFlexDatasetServiceURL")
-	filterHandler := helpers.CreateReverseProxy("filters", filterDatasetControllerURL) // CMD
+	filterHandler := helpers.CreateReverseProxy("filters", filterDatasetControllerURL)   // CMD
 	filterFlexHandler := helpers.CreateReverseProxy("flex", filterFlexDatasetServiceURL) // Cantabular
 
 	r.Path("/filters/{uri:.*}").HandlerFunc(handlers.FilterPageHandler(f.FilterClient, f.DatasetClient, filterHandler, filterFlexHandler))

--- a/service/mock/healthcheck.go
+++ b/service/mock/healthcheck.go
@@ -17,28 +17,28 @@ var _ service.HealthChecker = &HealthCheckerMock{}
 
 // HealthCheckerMock is a mock implementation of service.HealthChecker.
 //
-// 	func TestSomethingThatUsesHealthChecker(t *testing.T) {
+//	func TestSomethingThatUsesHealthChecker(t *testing.T) {
 //
-// 		// make and configure a mocked service.HealthChecker
-// 		mockedHealthChecker := &HealthCheckerMock{
-// 			AddCheckFunc: func(name string, checker healthcheck.Checker) error {
-// 				panic("mock out the AddCheck method")
-// 			},
-// 			HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
-// 				panic("mock out the Handler method")
-// 			},
-// 			StartFunc: func(ctx context.Context)  {
-// 				panic("mock out the Start method")
-// 			},
-// 			StopFunc: func()  {
-// 				panic("mock out the Stop method")
-// 			},
-// 		}
+//		// make and configure a mocked service.HealthChecker
+//		mockedHealthChecker := &HealthCheckerMock{
+//			AddCheckFunc: func(name string, checker healthcheck.Checker) error {
+//				panic("mock out the AddCheck method")
+//			},
+//			HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
+//				panic("mock out the Handler method")
+//			},
+//			StartFunc: func(ctx context.Context)  {
+//				panic("mock out the Start method")
+//			},
+//			StopFunc: func()  {
+//				panic("mock out the Stop method")
+//			},
+//		}
 //
-// 		// use mockedHealthChecker in code that requires service.HealthChecker
-// 		// and then make assertions.
+//		// use mockedHealthChecker in code that requires service.HealthChecker
+//		// and then make assertions.
 //
-// 	}
+//	}
 type HealthCheckerMock struct {
 	// AddCheckFunc mocks the AddCheck method.
 	AddCheckFunc func(name string, checker healthcheck.Checker) error
@@ -103,7 +103,8 @@ func (mock *HealthCheckerMock) AddCheck(name string, checker healthcheck.Checker
 
 // AddCheckCalls gets all the calls that were made to AddCheck.
 // Check the length with:
-//     len(mockedHealthChecker.AddCheckCalls())
+//
+//	len(mockedHealthChecker.AddCheckCalls())
 func (mock *HealthCheckerMock) AddCheckCalls() []struct {
 	Name    string
 	Checker healthcheck.Checker
@@ -138,7 +139,8 @@ func (mock *HealthCheckerMock) Handler(w http.ResponseWriter, req *http.Request)
 
 // HandlerCalls gets all the calls that were made to Handler.
 // Check the length with:
-//     len(mockedHealthChecker.HandlerCalls())
+//
+//	len(mockedHealthChecker.HandlerCalls())
 func (mock *HealthCheckerMock) HandlerCalls() []struct {
 	W   http.ResponseWriter
 	Req *http.Request
@@ -171,7 +173,8 @@ func (mock *HealthCheckerMock) Start(ctx context.Context) {
 
 // StartCalls gets all the calls that were made to Start.
 // Check the length with:
-//     len(mockedHealthChecker.StartCalls())
+//
+//	len(mockedHealthChecker.StartCalls())
 func (mock *HealthCheckerMock) StartCalls() []struct {
 	Ctx context.Context
 } {
@@ -199,7 +202,8 @@ func (mock *HealthCheckerMock) Stop() {
 
 // StopCalls gets all the calls that were made to Stop.
 // Check the length with:
-//     len(mockedHealthChecker.StopCalls())
+//
+//	len(mockedHealthChecker.StopCalls())
 func (mock *HealthCheckerMock) StopCalls() []struct {
 } {
 	var calls []struct {

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -17,25 +17,25 @@ var _ service.Initialiser = &InitialiserMock{}
 
 // InitialiserMock is a mock implementation of service.Initialiser.
 //
-// 	func TestSomethingThatUsesInitialiser(t *testing.T) {
+//	func TestSomethingThatUsesInitialiser(t *testing.T) {
 //
-// 		// make and configure a mocked service.Initialiser
-// 		mockedInitialiser := &InitialiserMock{
-// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
-// 				panic("mock out the DoGetHTTPServer method")
-// 			},
-// 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
-// 				panic("mock out the DoGetHealthCheck method")
-// 			},
-// 			DoGetHealthClientFunc: func(name string, url string) *health.Client {
-// 				panic("mock out the DoGetHealthClient method")
-// 			},
-// 		}
+//		// make and configure a mocked service.Initialiser
+//		mockedInitialiser := &InitialiserMock{
+//			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
+//				panic("mock out the DoGetHTTPServer method")
+//			},
+//			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+//				panic("mock out the DoGetHealthCheck method")
+//			},
+//			DoGetHealthClientFunc: func(name string, url string) *health.Client {
+//				panic("mock out the DoGetHealthClient method")
+//			},
+//		}
 //
-// 		// use mockedInitialiser in code that requires service.Initialiser
-// 		// and then make assertions.
+//		// use mockedInitialiser in code that requires service.Initialiser
+//		// and then make assertions.
 //
-// 	}
+//	}
 type InitialiserMock struct {
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
 	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
@@ -99,7 +99,8 @@ func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handle
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
 // Check the length with:
-//     len(mockedInitialiser.DoGetHTTPServerCalls())
+//
+//	len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
 	BindAddr string
 	Router   http.Handler
@@ -138,7 +139,8 @@ func (mock *InitialiserMock) DoGetHealthCheck(cfg *config.Config, buildTime stri
 
 // DoGetHealthCheckCalls gets all the calls that were made to DoGetHealthCheck.
 // Check the length with:
-//     len(mockedInitialiser.DoGetHealthCheckCalls())
+//
+//	len(mockedInitialiser.DoGetHealthCheckCalls())
 func (mock *InitialiserMock) DoGetHealthCheckCalls() []struct {
 	Cfg       *config.Config
 	BuildTime string
@@ -177,7 +179,8 @@ func (mock *InitialiserMock) DoGetHealthClient(name string, url string) *health.
 
 // DoGetHealthClientCalls gets all the calls that were made to DoGetHealthClient.
 // Check the length with:
-//     len(mockedInitialiser.DoGetHealthClientCalls())
+//
+//	len(mockedInitialiser.DoGetHealthClientCalls())
 func (mock *InitialiserMock) DoGetHealthClientCalls() []struct {
 	Name string
 	URL  string

--- a/service/mock/server.go
+++ b/service/mock/server.go
@@ -15,22 +15,22 @@ var _ service.HTTPServer = &HTTPServerMock{}
 
 // HTTPServerMock is a mock implementation of service.HTTPServer.
 //
-// 	func TestSomethingThatUsesHTTPServer(t *testing.T) {
+//	func TestSomethingThatUsesHTTPServer(t *testing.T) {
 //
-// 		// make and configure a mocked service.HTTPServer
-// 		mockedHTTPServer := &HTTPServerMock{
-// 			ListenAndServeFunc: func() error {
-// 				panic("mock out the ListenAndServe method")
-// 			},
-// 			ShutdownFunc: func(ctx context.Context) error {
-// 				panic("mock out the Shutdown method")
-// 			},
-// 		}
+//		// make and configure a mocked service.HTTPServer
+//		mockedHTTPServer := &HTTPServerMock{
+//			ListenAndServeFunc: func() error {
+//				panic("mock out the ListenAndServe method")
+//			},
+//			ShutdownFunc: func(ctx context.Context) error {
+//				panic("mock out the Shutdown method")
+//			},
+//		}
 //
-// 		// use mockedHTTPServer in code that requires service.HTTPServer
-// 		// and then make assertions.
+//		// use mockedHTTPServer in code that requires service.HTTPServer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type HTTPServerMock struct {
 	// ListenAndServeFunc mocks the ListenAndServe method.
 	ListenAndServeFunc func() error
@@ -68,7 +68,8 @@ func (mock *HTTPServerMock) ListenAndServe() error {
 
 // ListenAndServeCalls gets all the calls that were made to ListenAndServe.
 // Check the length with:
-//     len(mockedHTTPServer.ListenAndServeCalls())
+//
+//	len(mockedHTTPServer.ListenAndServeCalls())
 func (mock *HTTPServerMock) ListenAndServeCalls() []struct {
 } {
 	var calls []struct {
@@ -97,7 +98,8 @@ func (mock *HTTPServerMock) Shutdown(ctx context.Context) error {
 
 // ShutdownCalls gets all the calls that were made to Shutdown.
 // Check the length with:
-//     len(mockedHTTPServer.ShutdownCalls())
+//
+//	len(mockedHTTPServer.ShutdownCalls())
 func (mock *HTTPServerMock) ShutdownCalls() []struct {
 	Ctx context.Context
 } {


### PR DESCRIPTION
### What

There is currently a check in dp-frontend-router that determines the type of a dataset or a filter, and routes to either dp-frontend-filter-flex-dataset or dp-frontend-filter-dataset-controller depending on the dataset type. This check was removed from the frontend-router and moved to dp-frontend-filter-dataset-controller (which is the calling service), as the frontend-router should behave as a forwarding service only without any business logic.

https://jira.ons.gov.uk/browse/DIS-3020

Changes: 

- Updated config to include`FilterFlexDatasetServiceURL` `FrontendFilterDatasetControllerURL` 
- Brought in new `FilterPageHandler` handler which executes the business logic that was originally in `dp-frontend-router` 
- Updated routes.go to direct any incoming URLs that match `/filters/{uri:.*}` to this new handler
- **the `dp-frontend-router` version used in the `dp-frontend-filter-dataset-controller` go.mod will change when the new version is released to be able to use the newly exposed ParseURL and CreateReverseProxy functions — which is why the unit and linting tests are currently failing** 

### How to review
Set up dp-compose to utilise `dp-frontend-router` within the `dataset-catalogue` stack. And set the `API_ROUTER_URL` env variable for both `dp-dataset-router` and `dp-frontend-filter-dataset-controller` to `https://api.dp.aws.onsdigital.uk/v1` . This will point the services directly at the data in sandbox so that the cantabular and CMD pages can be tested locally. 

The `dataset-catalogue` stack can then be spun up with the changes in this PR for `dp-frontend-filter-dataset-controller` and those in https://github.com/ONSdigital/dp-frontend-router/pull/517 for `dp-frontend-router`

The behaviour that needs to be tested is:

- When a cantabular dataset landing page is accessed, and "change" is clicked alongside one of the variables, then the dp-frontend-filter-flex-dataset service is called, and the cantabular filter-flex journey works as it currently does.
- When a CMD dataset landing page is accessed, and "Filter and download" is clicked, then the dp-frontend-dataset-controller service is called, and the CMD filter journey works as it currently does.

To access the pages for testing, use the following: 
- Cantabular dataset landing page - https://dp.aws.onsdigital.uk/datasets/RM021/editions/2021/versions/32
- CMD dataset landing page - https://dp.aws.onsdigital.uk/datasets/cpih01/editions/time-series/versions/2

### Who can review

Anyone